### PR TITLE
Add support for enabling or disabling response metadata

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -49,10 +49,12 @@ export type {
 export type {
   TransportRequestParams,
   TransportRequestOptions,
+  TransportRequestOptionsWithMeta,
+  TransportRequestOptionsWithOutMeta,
   SniffOptions
 } from './lib/Transport'
 
-export type { Result } from './lib/types'
+export type { TransportResult, DiagnosticResult } from './lib/types'
 
 export {
   Diagnostic,

--- a/src/Diagnostic.ts
+++ b/src/Diagnostic.ts
@@ -20,10 +20,10 @@
 import { EventEmitter } from 'events'
 import { ElasticsearchClientError, ConfigurationError } from './errors'
 import { ConnectionRequestOptions } from './connection'
-import { Result } from './types'
+import { DiagnosticResult } from './types'
 
 export type DiagnosticListener = (err: ElasticsearchClientError | null, meta: any | null) => void
-export type DiagnosticListenerFull = (err: ElasticsearchClientError | null, meta: Result | null) => void
+export type DiagnosticListenerFull = (err: ElasticsearchClientError | null, meta: DiagnosticResult | null) => void
 export type DiagnosticListenerLight = (err: ElasticsearchClientError | null, meta: ConnectionRequestOptions | null) => void
 
 export enum events {

--- a/src/Transport.ts
+++ b/src/Transport.ts
@@ -94,7 +94,7 @@ export interface TransportOptions {
   sniffOnStart?: boolean
   nodeFilter?: nodeFilterFn
   nodeSelector?: nodeSelectorFn
-  headers?: Record<string, string>
+  headers?: http.IncomingHttpHeaders
   generateRequestId?: generateRequestIdFn
   name?: string
   opaqueIdPrefix?: string
@@ -122,6 +122,26 @@ export interface TransportRequestOptions {
   warnings?: string[]
   opaqueId?: string
   abortController?: AbortController
+  /**
+    * Warning: If you set meta to true the result will no longer be
+    * the response body, but an object containing the body, statusCode,
+    * headers and meta keys.
+    * You can use the destructuring assignment to update your code without
+    * refactoring the entire code base:
+    * From:
+    * ```
+    * const result = await client.method(params)
+    * ```
+    * To:
+    * ```
+    * const {
+    *   body: result,
+    *   statusCode,
+    *   headers,
+    *   meta
+    * } = await client.method(params, { meta: true })
+    * ```
+    */
   meta?: boolean
 }
 

--- a/src/connection/HttpConnection.ts
+++ b/src/connection/HttpConnection.ts
@@ -150,7 +150,7 @@ export default class HttpConnection extends BaseConnection {
           resolve({
             body: isCompressed ? Buffer.concat(payload as Buffer[]) : payload as string,
             statusCode: response.statusCode as number,
-            headers: response.headers as Record<string, string>
+            headers: response.headers
           })
         }
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -18,7 +18,7 @@
  */
 
 import * as http from 'http'
-import { Result } from './types'
+import { DiagnosticResult } from './types'
 
 export class ElasticsearchClientError extends Error {
   constructor (message: string) {
@@ -28,8 +28,8 @@ export class ElasticsearchClientError extends Error {
 }
 
 export class TimeoutError extends ElasticsearchClientError {
-  meta?: Result
-  constructor (message: string, meta?: Result) {
+  meta?: DiagnosticResult
+  constructor (message: string, meta?: DiagnosticResult) {
     super(message)
     Error.captureStackTrace(this, TimeoutError)
     this.name = 'TimeoutError'
@@ -39,8 +39,8 @@ export class TimeoutError extends ElasticsearchClientError {
 }
 
 export class ConnectionError extends ElasticsearchClientError {
-  meta?: Result
-  constructor (message: string, meta?: Result) {
+  meta?: DiagnosticResult
+  constructor (message: string, meta?: DiagnosticResult) {
     super(message)
     Error.captureStackTrace(this, ConnectionError)
     this.name = 'ConnectionError'
@@ -50,8 +50,8 @@ export class ConnectionError extends ElasticsearchClientError {
 }
 
 export class NoLivingConnectionsError extends ElasticsearchClientError {
-  meta: Result
-  constructor (message: string, meta: Result) {
+  meta: DiagnosticResult
+  constructor (message: string, meta: DiagnosticResult) {
     super(message)
     Error.captureStackTrace(this, NoLivingConnectionsError)
     this.name = 'NoLivingConnectionsError'
@@ -92,12 +92,12 @@ export class ConfigurationError extends ElasticsearchClientError {
 }
 
 export class ResponseError extends ElasticsearchClientError {
-  meta: Result
-  constructor (meta: Result) {
+  meta: DiagnosticResult
+  constructor (meta: DiagnosticResult) {
     super('Response Error')
     Error.captureStackTrace(this, ResponseError)
     this.name = 'ResponseError'
-    this.message = typeof meta.body === 'object'
+    this.message = isObject(meta.body)
       ? meta.body?.error?.type ?? 'Response Error'
       : 'Response Error'
     this.meta = meta
@@ -108,7 +108,7 @@ export class ResponseError extends ElasticsearchClientError {
   }
 
   get statusCode (): number | undefined {
-    if (typeof this.meta.body === 'object' && typeof this.meta.body.status === 'number') {
+    if (isObject(this.meta.body) && typeof this.meta.body.status === 'number') {
       return this.meta.body.status
     }
     return this.meta.statusCode
@@ -120,12 +120,16 @@ export class ResponseError extends ElasticsearchClientError {
 }
 
 export class RequestAbortedError extends ElasticsearchClientError {
-  meta?: Result
-  constructor (message: string, meta?: Result) {
+  meta?: DiagnosticResult
+  constructor (message: string, meta?: DiagnosticResult) {
     super(message)
     Error.captureStackTrace(this, RequestAbortedError)
     this.name = 'RequestAbortedError'
     this.message = message ?? 'Request aborted'
     this.meta = meta
   }
+}
+
+function isObject (obj: any): obj is Record<string, any> {
+  return typeof obj === 'object'
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,7 +52,11 @@ export interface DiagnosticResult<TResponse = unknown, TContext = Context> {
   }
 }
 
-export type TransportResult<TResponse = unknown, TContext = Context> = Required<DiagnosticResult<TResponse, TContext>>
+export interface TransportResult<TResponse = unknown, TContext = Context> extends DiagnosticResult<TResponse, TContext> {
+  body: TResponse
+  statusCode: number
+  headers: http.IncomingHttpHeaders
+}
 
 export declare type agentFn = (opts: ConnectionOptions) => any
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,7 +29,7 @@ export type RequestBody<T = Record<string, any>> = T | string | Buffer | Readabl
 
 export type RequestNDBody<T = Array<Record<string, any>>> = T | string | string[] | Buffer | ReadableStream
 
-export interface Result<TResponse = any, TContext = Context> {
+export interface DiagnosticResult<TResponse = unknown, TContext = Context> {
   body?: TResponse
   statusCode?: number
   headers?: http.IncomingHttpHeaders
@@ -51,6 +51,8 @@ export interface Result<TResponse = any, TContext = Context> {
     }
   }
 }
+
+export type TransportResult<TResponse = unknown, TContext = Context> = Required<DiagnosticResult<TResponse, TContext>>
 
 export declare type agentFn = (opts: ConnectionOptions) => any
 

--- a/test/unit/diagnostic.test.ts
+++ b/test/unit/diagnostic.test.ts
@@ -19,7 +19,7 @@
 
 import { test } from 'tap'
 import { URL } from 'url'
-import { Diagnostic, HttpConnection, errors, Result, events } from '../..'
+import { Diagnostic, HttpConnection, errors, DiagnosticResult, events } from '../..'
 const { ConnectionError, ConfigurationError } = errors
 
 const mmeta = {
@@ -71,7 +71,7 @@ test('off', t => {
   t.plan(2)
   const d = new Diagnostic()
 
-  function handler (err: errors.ElasticsearchClientError | null, meta: Result | null) {
+  function handler (err: errors.ElasticsearchClientError | null, meta: DiagnosticResult | null) {
     t.true(err instanceof ConnectionError)
     t.deepEqual(meta, mmeta)
   }

--- a/test/unit/transport.test.ts
+++ b/test/unit/transport.test.ts
@@ -85,7 +85,7 @@ test('Basic', async t => {
   const res = await transport.request({
     method: 'GET',
     path: '/hello'
-  })
+  }, { meta: true })
   t.deepEqual(res.body, { hello: 'world' })
   t.strictEqual(res.statusCode, 200)
   t.strictEqual(res.headers?.['content-type'], 'application/json;utf=8')
@@ -143,7 +143,7 @@ test('Basic error (ConnectionError)', async t => {
     await transport.request({
       method: 'GET',
       path: '/hello'
-    })
+    }, { meta: true })
   } catch (err) {
     t.true(err instanceof ConnectionError)
   }
@@ -157,7 +157,7 @@ test('Ignore status code', async t => {
 
   const res = await transport.request(
     { method: 'GET', path: '/404' },
-    { ignore: [404] }
+    { ignore: [404], meta: true }
   )
   t.deepEqual(res.body, { hello: 'world' })
   t.strictEqual(res.statusCode, 404)
@@ -183,7 +183,7 @@ test('Send POST (json)', async t => {
     method: 'POST',
     path: '/hello',
     body: { hello: 'world' }
-  })
+  }, { meta: true })
   t.deepEqual(res.body, { hello: 'world' })
   t.strictEqual(res.statusCode, 200)
   t.strictEqual(res.headers?.['content-type'], 'application/json;utf=8')
@@ -220,7 +220,7 @@ test('Send POST (ndjson)', async t => {
     method: 'POST',
     path: '/hello',
     bulkBody
-  })
+  }, { meta: true })
   t.strictEqual(res.statusCode, 200)
 })
 
@@ -246,7 +246,7 @@ test('Send stream (json)', async t => {
     method: 'POST',
     path: '/hello',
     body: intoStream(JSON.stringify({ hello: 'world' }))
-  })
+  }, { meta: true })
   t.strictEqual(res.statusCode, 200)
 })
 
@@ -279,7 +279,7 @@ test('Send stream (ndjson)', async t => {
     method: 'POST',
     path: '/hello',
     bulkBody: intoStream(s.ndserialize(bulkBody))
-  })
+  }, { meta: true })
   t.strictEqual(res.statusCode, 200)
 })
 
@@ -302,7 +302,7 @@ test('Not JSON payload from server', async t => {
   const res = await transport.request({
     method: 'GET',
     path: '/hello'
-  })
+  }, { meta: true })
   t.strictEqual(res.statusCode, 200)
   t.strictEqual(res.body, 'hello!')
 })
@@ -418,7 +418,7 @@ test('Retry mechanism', async t => {
   const res = await transport.request({
     method: 'GET',
     path: '/hello'
-  })
+  }, { meta: true })
   t.deepEqual(res.body, { hello: 'world' })
   t.strictEqual(res.statusCode, 200)
   t.strictEqual(res.meta.attempts, 2)
@@ -551,7 +551,7 @@ test('Override global maxRetries', async t => {
 
   const res = await transport.request(
     { method: 'GET', path: '/hello' },
-    { maxRetries: 3 }
+    { maxRetries: 3, meta: true }
   )
   t.deepEqual(res.body, { hello: 'world' })
   t.strictEqual(res.statusCode, 200)
@@ -648,7 +648,7 @@ test('Serialize querystring', async t => {
       foo: 'bar',
       baz: 'faz'
     }
-  })
+  }, { meta: true })
   t.strictEqual(res.statusCode, 200)
 })
 
@@ -679,7 +679,8 @@ test('Serialize querystring (merge with options)', async t => {
   }, {
     querystring: {
       baz: 'faz'
-    }
+    },
+    meta: true
   })
   t.strictEqual(res.statusCode, 200)
 })
@@ -695,7 +696,7 @@ test('Should cast to boolean HEAD request (true)', async t => {
   const res = await transport.request({
     method: 'HEAD',
     path: '/hello'
-  })
+  }, { meta: true })
   t.strictEqual(res.body, true)
   t.strictEqual(res.statusCode, 200)
 })
@@ -720,7 +721,7 @@ test('Should cast to boolean HEAD request (false)', async t => {
   const res = await transport.request({
     method: 'HEAD',
     path: '/hello'
-  })
+  }, { meta: true })
   t.strictEqual(res.body, false)
   t.strictEqual(res.statusCode, 404)
 })
@@ -753,7 +754,7 @@ test('Enable compression (gzip response)', async t => {
     method: 'POST',
     path: '/hello',
     body: { hello: 'world' }
-  })
+  }, { meta: true })
   t.strictEqual(res.headers?.['content-encoding'], 'gzip')
   t.deepEqual(res.body, { hello: 'world' })
   t.strictEqual(res.statusCode, 200)
@@ -787,7 +788,7 @@ test('Enable compression (deflate response)', async t => {
     method: 'POST',
     path: '/hello',
     body: { hello: 'world' }
-  })
+  }, { meta: true })
   t.strictEqual(res.headers?.['content-encoding'], 'deflate')
   t.deepEqual(res.body, { hello: 'world' })
   t.strictEqual(res.statusCode, 200)
@@ -822,7 +823,7 @@ test('Retry compressed request', async t => {
     method: 'POST',
     path: '/hello',
     body: { hello: 'world' }
-  })
+  }, { meta: true })
   t.strictEqual(res.meta.attempts, 2)
 })
 
@@ -888,7 +889,7 @@ test('Compress stream', async t => {
     method: 'POST',
     path: '/hello',
     body: intoStream(JSON.stringify({ hello: 'world' }))
-  })
+  }, { meta: true })
   t.strictEqual(res.headers?.['content-encoding'], 'gzip')
   t.deepEqual(res.body, { hello: 'world' })
   t.strictEqual(res.statusCode, 200)
@@ -917,7 +918,7 @@ test('Warning header (single)', async t => {
   const res = await transport.request({
     method: 'GET',
     path: '/hello'
-  })
+  }, { meta: true })
   t.deepEqual(res.warnings, [warn])
 })
 
@@ -946,7 +947,7 @@ test('Warning header (multiple)', async t => {
   const res = await transport.request({
     method: 'GET',
     path: '/hello'
-  })
+  }, { meta: true })
   t.deepEqual(res.warnings, [warn1, warn2])
 })
 
@@ -962,7 +963,7 @@ test('No warnings', async t => {
   const res = await transport.request({
     method: 'GET',
     path: '/hello'
-  })
+  }, { meta: true })
   t.strictEqual(res.warnings, null)
 })
 
@@ -988,7 +989,7 @@ test('Custom global headers', async t => {
   const res = await transport.request({
     method: 'GET',
     path: '/hello'
-  })
+  }, { meta: true })
   t.strictEqual(res.statusCode, 200)
 })
 
@@ -1012,7 +1013,8 @@ test('Custom local headers', async t => {
     method: 'GET',
     path: '/hello'
   }, {
-    headers: { 'x-foo': 'bar' }
+    headers: { 'x-foo': 'bar' },
+    meta: true
   })
   t.strictEqual(res.statusCode, 200)
 })
@@ -1044,7 +1046,8 @@ test('Merge local and global headers', async t => {
     headers: {
       'x-foo': 'bar2',
       'x-faz': 'baz'
-    }
+    },
+    meta: true
   })
   t.strictEqual(res.statusCode, 200)
 })
@@ -1071,7 +1074,7 @@ test('Node filter and node selector', async t => {
   const res = await transport.request({
     method: 'GET',
     path: '/hello'
-  })
+  }, { meta: true })
   t.strictEqual(res.statusCode, 200)
 })
 
@@ -1099,7 +1102,7 @@ test('User-Agent header', async t => {
   const res = await transport.request({
     method: 'GET',
     path: '/hello'
-  })
+  }, { meta: true })
   t.strictEqual(res.statusCode, 200)
 })
 
@@ -1113,7 +1116,7 @@ test('generateRequestId', async t => {
     connectionPool: pool,
     generateRequestId (params: TransportRequestParams, options: TransportRequestOptions) {
       t.deepEqual(params, { method: 'GET', path: '/hello' })
-      t.deepEqual(options, { ignore: [404] })
+      t.deepEqual(options, { ignore: [404], meta: true })
       return 42
     }
   })
@@ -1125,7 +1128,7 @@ test('generateRequestId', async t => {
 
   const res = await transport.request(
     { method: 'GET', path: '/hello' },
-    { ignore: [404] }
+    { ignore: [404], meta: true }
   )
   t.strictEqual(res.statusCode, 200)
 })
@@ -1145,7 +1148,7 @@ test('custom request id', async t => {
 
   const res = await transport.request(
     { method: 'GET', path: '/hello' },
-    { id: 42 }
+    { id: 42, meta: true }
   )
   t.strictEqual(res.statusCode, 200)
 })
@@ -1169,7 +1172,7 @@ test('No opaque id by default', async t => {
   const res = await transport.request({
     method: 'GET',
     path: '/hello'
-  })
+  }, { meta: true })
   t.strictEqual(res.statusCode, 200)
 })
 
@@ -1193,7 +1196,8 @@ test('Opaque id', async t => {
     method: 'GET',
     path: '/hello'
   }, {
-    opaqueId: 'foo'
+    opaqueId: 'foo',
+    meta: true
   })
   t.strictEqual(res.statusCode, 200)
 })
@@ -1221,7 +1225,8 @@ test('Opaque id and prefix', async t => {
     method: 'GET',
     path: '/hello'
   }, {
-    opaqueId: 'foo'
+    opaqueId: 'foo',
+    meta: true
   })
   t.strictEqual(res.statusCode, 200)
 })
@@ -1248,7 +1253,7 @@ test('Opaque id prefix', async t => {
   const res = await transport.request({
     method: 'GET',
     path: '/hello'
-  })
+  }, { meta: true })
   t.strictEqual(res.statusCode, 200)
 })
 
@@ -1271,7 +1276,7 @@ test('global context', async t => {
   const res = await transport.request({
     method: 'GET',
     path: '/hello'
-  })
+  }, { meta: true })
   t.strictEqual(res.statusCode, 200)
 })
 
@@ -1292,7 +1297,8 @@ test('local context', async t => {
     method: 'GET',
     path: '/hello'
   }, {
-    context: { hello: 'world' }
+    context: { hello: 'world' },
+    meta: true
   })
   t.strictEqual(res.statusCode, 200)
 })
@@ -1317,7 +1323,8 @@ test('local and global context', async t => {
     method: 'GET',
     path: '/hello'
   }, {
-    context: { hello: 'world2' }
+    context: { hello: 'world2' },
+    meta: true
   })
   t.strictEqual(res.statusCode, 200)
 })
@@ -1412,7 +1419,7 @@ test('Sniff interval', async t => {
   let res = await transport.request({
     method: 'GET',
     path: '/hello'
-  })
+  }, { meta: true })
   t.strictEqual(res.statusCode, 200)
 
   await sleep(80)
@@ -1420,7 +1427,7 @@ test('Sniff interval', async t => {
   res = await transport.request({
     method: 'GET',
     path: '/hello'
-  })
+  }, { meta: true })
   t.strictEqual(res.statusCode, 200)
 
   await sleep(80)
@@ -1428,7 +1435,7 @@ test('Sniff interval', async t => {
   res = await transport.request({
     method: 'GET',
     path: '/hello'
-  })
+  }, { meta: true })
   t.strictEqual(res.statusCode, 200)
 })
 
@@ -1479,6 +1486,51 @@ test('sniffInterval should be false or a positive integer', t => {
   } catch (err) {
     t.true(err instanceof ConfigurationError)
   }
+})
+
+test('No meta', async t => {
+  t.plan(1)
+
+  const pool = new WeightedConnectionPool({ Connection: MockConnection })
+  pool.addConnection('http://localhost:9200')
+
+  const transport = new Transport({ connectionPool: pool })
+
+  const res = await transport.request({
+    method: 'GET',
+    path: '/hello'
+  })
+  t.deepEqual(res, { hello: 'world' })
+})
+
+test('meta is false', async t => {
+  t.plan(1)
+
+  const pool = new WeightedConnectionPool({ Connection: MockConnection })
+  pool.addConnection('http://localhost:9200')
+
+  const transport = new Transport({ connectionPool: pool })
+
+  const res = await transport.request({
+    method: 'GET',
+    path: '/hello'
+  }, { meta: false })
+  t.deepEqual(res, { hello: 'world' })
+})
+
+test('meta is true', async t => {
+  t.plan(1)
+
+  const pool = new WeightedConnectionPool({ Connection: MockConnection })
+  pool.addConnection('http://localhost:9200')
+
+  const transport = new Transport({ connectionPool: pool })
+
+  const res = await transport.request({
+    method: 'GET',
+    path: '/hello'
+  }, { meta: true })
+  t.deepEqual(res.body, { hello: 'world' })
 })
 
 // test('asStream set to true', t => {

--- a/test/utils/TestClient.ts
+++ b/test/utils/TestClient.ts
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+import assert from 'assert'
 import {
   Transport,
   HttpConnection,
@@ -39,8 +40,9 @@ class SniffingTransport extends Transport {
       path: this.sniffEndpoint ?? '/_nodes/_all/http'
     }
 
-    this.request(request, { id: opts.requestId })
+    this.request(request, { id: opts.requestId, meta: true })
       .then(result => {
+        assert(isObject(result.body), 'The body should be an object')
         this.isSniffing = false
         const protocol = result.meta.connection?.url.protocol || /* istanbul ignore next */ 'http:'
         const hosts = this.connectionPool.nodesToHost(result.body.nodes, protocol)
@@ -55,6 +57,10 @@ class SniffingTransport extends Transport {
         this.diagnostic.emit('sniff', err, null)
       })
   }
+}
+
+function isObject (obj: any): obj is Record<string, any> {
+  return typeof obj === 'object'
 }
 
 export default class TestClient {


### PR DESCRIPTION
As titled.

```js
// without response metadata
const result = await transport.request(
  { method: 'GET', path: '/' }
)
console.log(result) // the response body

// with response metadata
const result = await transport.request(
  { method: 'GET', path: '/' },
  { meta: true }
)
console.log(result.body)
console.log(result.statusCode)
console.log(result.headers)
console.log(result.meta)
```