### PR TITLE
Move all symbols in a single registry

### DIFF
--- a/src/Serializer.ts
+++ b/src/Serializer.ts
@@ -22,9 +22,9 @@ import Debug from 'debug'
 // @ts-expect-error
 import sjson from 'secure-json-parse'
 import { SerializationError, DeserializationError } from './errors'
+import { kJsonOptions } from './symbols'
 
 const debug = Debug('elasticsearch')
-const kJsonOptions = Symbol('secure json parse options')
 
 export interface SerializerOptions {
   disablePrototypePoisoningProtection?: boolean | 'proto' | 'constructor'

--- a/src/Transport.ts
+++ b/src/Transport.ts
@@ -51,32 +51,33 @@ import {
   TransportResult,
   Context
 } from './types'
+import {
+  kSniffEnabled,
+  kNextSniff,
+  kIsSniffing,
+  kSniffInterval,
+  kSniffOnConnectionFault,
+  kSniffEndpoint,
+  kRequestTimeout,
+  kCompression,
+  kMaxRetries,
+  kName,
+  kOpaqueIdPrefix,
+  kGenerateRequestId,
+  kContext,
+  kConnectionPool,
+  kSerializer,
+  kDiagnostic,
+  kHeaders,
+  kNodeFilter,
+  kNodeSelector
+} from './symbols'
 
 const { version: clientVersion } = require('../package.json') // eslint-disable-line
 const debug = Debug('elasticsearch')
 const gzip = promisify(zlib.gzip)
 const unzip = promisify(zlib.unzip)
 const { createGzip } = zlib
-
-const kSniffEnabled = Symbol('sniff enabled')
-const kNextSniff = Symbol('next sniff')
-const kIsSniffing = Symbol('is sniffing')
-const kSniffInterval = Symbol('sniff interval')
-const kSniffOnConnectionFault = Symbol('sniff on connection fault')
-const kSniffEndpoint = Symbol('sniff endpoint')
-const kRequestTimeout = Symbol('request timeout')
-const kCompression = Symbol('compression')
-const kMaxRetries = Symbol('max retries')
-const kName = Symbol('name')
-const kOpaqueIdPrefix = Symbol('opaque id prefix')
-const kGenerateRequestId = Symbol('generate request id')
-const kContext = Symbol('context')
-const kConnectionPool = Symbol('connection pool')
-const kSerializer = Symbol('serializer')
-const kDiagnostic = Symbol('diagnostics')
-const kHeaders = Symbol('headers')
-const kNodeFilter = Symbol('node filter')
-const kNodeSelector = Symbol('node selector')
 
 const userAgent = `elastic-transport-js/${clientVersion} (${os.platform()} ${os.release()}-${os.arch()}; Node.js ${process.version})` // eslint-disable-line
 

--- a/src/connection/BaseConnection.ts
+++ b/src/connection/BaseConnection.ts
@@ -32,9 +32,7 @@ import {
   agentFn
 } from '../types'
 import { ConfigurationError } from '../errors'
-
-const kStatus = Symbol('status')
-const kDiagnostic = Symbol('diagnostics')
+import { kStatus, kDiagnostic } from '../symbols'
 
 export interface ConnectionOptions {
   url: URL

--- a/src/connection/UndiciConnection.ts
+++ b/src/connection/UndiciConnection.ts
@@ -35,12 +35,12 @@ import {
 } from '../errors'
 import { TlsOptions } from 'tls'
 import { UndiciAgentOptions } from '../types'
+import { kEmitter } from '../symbols'
 
 const debug = Debug('elasticsearch')
 const INVALID_PATH_REGEX = /[^\u0021-\u00ff]/
 const MAX_BUFFER_LENGTH = buffer.constants.MAX_LENGTH
 const MAX_STRING_LENGTH = buffer.constants.MAX_STRING_LENGTH
-const kEmitter = Symbol('event emitter')
 
 export default class Connection extends BaseConnection {
   pool: Pool

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -1,0 +1,41 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export const kSniffEnabled = Symbol('sniff enabled')
+export const kNextSniff = Symbol('next sniff')
+export const kIsSniffing = Symbol('is sniffing')
+export const kSniffInterval = Symbol('sniff interval')
+export const kSniffOnConnectionFault = Symbol('sniff on connection fault')
+export const kSniffEndpoint = Symbol('sniff endpoint')
+export const kRequestTimeout = Symbol('request timeout')
+export const kCompression = Symbol('compression')
+export const kMaxRetries = Symbol('max retries')
+export const kName = Symbol('name')
+export const kOpaqueIdPrefix = Symbol('opaque id prefix')
+export const kGenerateRequestId = Symbol('generate request id')
+export const kContext = Symbol('context')
+export const kConnectionPool = Symbol('connection pool')
+export const kSerializer = Symbol('serializer')
+export const kDiagnostic = Symbol('diagnostics')
+export const kHeaders = Symbol('headers')
+export const kNodeFilter = Symbol('node filter')
+export const kNodeSelector = Symbol('node selector')
+export const kJsonOptions = Symbol('secure json parse options')
+export const kStatus = Symbol('status')
+export const kEmitter = Symbol('event emitter')


### PR DESCRIPTION
As titled.

This will make easier to perform advanced testing in libraries that depend on this one.