### PR TITLE
Disable prototype poisoning protection by default

### DIFF
--- a/src/Serializer.ts
+++ b/src/Serializer.ts
@@ -26,7 +26,7 @@ import { kJsonOptions } from './symbols'
 const debug = Debug('elasticsearch')
 
 export interface SerializerOptions {
-  disablePrototypePoisoningProtection?: boolean | 'proto' | 'constructor'
+  enablePrototypePoisoningProtection?: boolean | 'proto' | 'constructor'
 }
 
 export default class Serializer {
@@ -36,10 +36,10 @@ export default class Serializer {
   }
 
   constructor (opts: SerializerOptions = {}) {
-    const disable = opts.disablePrototypePoisoningProtection
+    const enabled = opts.enablePrototypePoisoningProtection ?? false
     this[kJsonOptions] = {
-      protoAction: disable === true || disable === 'proto' ? 'ignore' : 'error',
-      constructorAction: disable === true || disable === 'constructor' ? 'ignore' : 'error'
+      protoAction: enabled === true || enabled === 'proto' ? 'error' : 'ignore',
+      constructorAction: enabled === true || enabled === 'constructor' ? 'error' : 'ignore'
     }
   }
 

--- a/test/unit/serializer.test.ts
+++ b/test/unit/serializer.test.ts
@@ -168,29 +168,29 @@ test('DeserializationError', t => {
   }
 })
 
-test('prototype poisoning protection', t => {
+test('prototype poisoning protection enabled', t => {
+   t.plan(2)
+   const s = new Serializer({ enablePrototypePoisoningProtection: true })
+   try {
+     s.deserialize('{"__proto__":{"foo":"bar"}}')
+     t.fail('Should fail')
+   } catch (err) {
+     t.ok(err instanceof DeserializationError)
+   }
+
+   try {
+     s.deserialize('{"constructor":{"prototype":{"foo":"bar"}}}')
+     t.fail('Should fail')
+   } catch (err) {
+     t.ok(err instanceof DeserializationError)
+   }
+ })
+
+ test('disabled prototype poisoning protection by default', t => {
    t.plan(2)
    const s = new Serializer()
    try {
      s.deserialize('{"__proto__":{"foo":"bar"}}')
-     t.fail('Should fail')
-   } catch (err) {
-     t.ok(err instanceof DeserializationError)
-   }
-
-   try {
-     s.deserialize('{"constructor":{"prototype":{"foo":"bar"}}}')
-     t.fail('Should fail')
-   } catch (err) {
-     t.ok(err instanceof DeserializationError)
-   }
- })
-
- test('disable prototype poisoning protection', t => {
-   t.plan(2)
-   const s = new Serializer({ disablePrototypePoisoningProtection: true })
-   try {
-     s.deserialize('{"__proto__":{"foo":"bar"}}')
      t.pass('Should not fail')
    } catch (err) {
      t.fail(err)
@@ -204,38 +204,38 @@ test('prototype poisoning protection', t => {
    }
  })
 
- test('disable prototype poisoning protection only for proto', t => {
+ test('enable prototype poisoning protection only for proto', t => {
    t.plan(2)
-   const s = new Serializer({ disablePrototypePoisoningProtection: 'proto' })
+   const s = new Serializer({ enablePrototypePoisoningProtection: 'proto' })
    try {
      s.deserialize('{"__proto__":{"foo":"bar"}}')
-     t.pass('Should not fail')
+     t.fail('Should fail')
    } catch (err) {
-     t.fail(err)
+     t.ok(err instanceof DeserializationError)
    }
 
    try {
      s.deserialize('{"constructor":{"prototype":{"foo":"bar"}}}')
-     t.fail('Should fail')
+     t.pass('Should not fail')
    } catch (err) {
-     t.ok(err instanceof DeserializationError)
+     t.fail(err)
    }
  })
 
  test('disable prototype poisoning protection only for constructor', t => {
    t.plan(2)
-   const s = new Serializer({ disablePrototypePoisoningProtection: 'constructor' })
+   const s = new Serializer({ enablePrototypePoisoningProtection: 'constructor' })
    try {
      s.deserialize('{"__proto__":{"foo":"bar"}}')
-     t.fail('Should fail')
+     t.pass('Should not fail')
    } catch (err) {
-     t.ok(err instanceof DeserializationError)
+     t.fail(err)
    }
 
    try {
      s.deserialize('{"constructor":{"prototype":{"foo":"bar"}}}')
-     t.pass('Should not fail')
+     t.fail('Should fail')
    } catch (err) {
-     t.fail(err)
+     t.ok(err instanceof DeserializationError)
    }
  })


### PR DESCRIPTION
As titled.

Also renamed the serializer option `disablePrototypePoisoningProtection` to `enablePrototypePoisoningProtection`.

Related: https://github.com/elastic/elasticsearch-js/pull/1503