### PR TITLE
Show the body as string if the response error can't be read as ES error

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -105,8 +105,10 @@ export class ResponseError extends ElasticsearchClientError {
       } else {
         this.message = meta.body.error.type
       }
+    } else if (typeof meta.body === 'object' && meta.body != null) {
+      this.message = JSON.stringify(meta.body)
     } else {
-      this.message = 'Response Error'
+      this.message = meta.body as string ?? 'Response Error'
     }
     this.meta = meta
   }


### PR DESCRIPTION
As titled.

Related: https://github.com/elastic/elasticsearch-js/pull/1509