### PR TITLE
Show socket local/remote address in case of ECONNRESET

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "ms": "^2.1.3",
     "secure-json-parse": "^2.4.0",
     "tslib": "^2.3.0",
-    "undici": "^4.3.1"
+    "undici": "^4.7.0"
   },
   "tap": {
     "ts": true,

--- a/src/connection/HttpConnection.ts
+++ b/src/connection/HttpConnection.ts
@@ -187,7 +187,12 @@ export default class HttpConnection extends BaseConnection {
       const onError = (err: Error): void => {
         cleanListeners()
         this._openRequests--
-        reject(new ConnectionError(err.message))
+        let message = err.message
+        // @ts-expect-error
+        if (err.code === 'ECONNRESET') {
+          message += ` - Local: ${request.socket?.localAddress ?? ''}:${request.socket?.localPort ?? ''}, Remote: ${request.socket?.remoteAddress ?? ''}:${request.socket?.remotePort ?? ''}`
+        }
+        reject(new ConnectionError(message))
       }
 
       const onAbort = (): void => {

--- a/src/connection/HttpConnection.ts
+++ b/src/connection/HttpConnection.ts
@@ -190,7 +190,7 @@ export default class HttpConnection extends BaseConnection {
         let message = err.message
         // @ts-expect-error
         if (err.code === 'ECONNRESET') {
-          message += ` - Local: ${request.socket?.localAddress ?? ''}:${request.socket?.localPort ?? ''}, Remote: ${request.socket?.remoteAddress ?? ''}:${request.socket?.remotePort ?? ''}`
+          message += ` - Local: ${request.socket?.localAddress ?? 'unknown'}:${request.socket?.localPort ?? 'unknown'}, Remote: ${request.socket?.remoteAddress ?? 'unknown'}:${request.socket?.remotePort ?? 'unknown'}`
         }
         reject(new ConnectionError(message))
       }

--- a/src/connection/UndiciConnection.ts
+++ b/src/connection/UndiciConnection.ts
@@ -156,6 +156,8 @@ export default class Connection extends BaseConnection {
           throw (timedout ? new TimeoutError('Request timed out') : new RequestAbortedError('Request aborted'))
         case 'UND_ERR_HEADERS_TIMEOUT':
           throw new TimeoutError('Request timed out')
+        case 'UND_ERR_SOCKET':
+          throw new ConnectionError(`${err.message} - Local: ${err.socket?.localAddress ?? 'unknown'}:${err.socket?.localPort ?? 'unknown'}, Remote: ${err.socket?.remoteAddress ?? 'unknown'}:${err.socket?.remotePort ?? 'unknown'}`) // eslint-disable-line
         default:
           throw new ConnectionError(err.message)
       }

--- a/test/unit/http-connection.test.ts
+++ b/test/unit/http-connection.test.ts
@@ -29,12 +29,12 @@ import intoStream from 'into-stream'
 import AbortController from 'node-abort-controller'
 import { buildServer } from '../utils'
 import { HttpConnection, errors, ConnectionOptions } from '../../'
-import { ConfigurationError } from '../../lib/errors'
 
 const {
   TimeoutError,
   RequestAbortedError,
-  ConnectionError
+  ConnectionError,
+  ConfigurationError
 } = errors
 
 const options = {
@@ -1109,6 +1109,30 @@ test('Check server fingerprint (failure)', async t => {
   } catch (err: any) {
     t.ok(err instanceof ConnectionError)
     t.equal(err.message, 'Server certificate CA fingerprint does not match the value configured in caFingerprint')
+  }
+  server.stop()
+})
+
+test('Should show local/remote socket addres in case of ECONNRESET', async t => {
+  t.plan(2)
+
+  function handler (req: http.IncomingMessage, res: http.ServerResponse) {
+    res.destroy()
+  }
+
+  const [{ port }, server] = await buildServer(handler)
+  const connection = new HttpConnection({
+    url: new URL(`http://localhost:${port}`)
+  })
+  try {
+    await connection.request({
+      path: '/hello',
+      method: 'GET'
+    }, options)
+    t.fail('should throw')
+  } catch (err: any) {
+    t.ok(err instanceof ConnectionError)
+    t.match(err.message, /socket\shang\sup\s-\sLocal:\s127.0.0.1:\d+,\sRemote:\s127.0.0.1:\d+/)
   }
   server.stop()
 })


### PR DESCRIPTION
As titled.

Related: https://github.com/elastic/elasticsearch-js/pull/1555

Waiting for https://github.com/nodejs/undici/pull/1041 for having the same feature in `UndiciConnection`.