### PR TITLE
address feedback from kibana upgrade

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -54,7 +54,16 @@ export type {
   SniffOptions
 } from './lib/Transport'
 
-export type { TransportResult, DiagnosticResult } from './lib/types'
+export type {
+  RequestBody,
+  RequestNDBody,
+  DiagnosticResult
+  TransportResult,
+  HttpAgentOptions,
+  UndiciAgentOptions,
+  ApiKeyAuth,
+  BearerAuth
+} from './lib/types'
 
 export {
   Diagnostic,

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,7 +29,7 @@ export type RequestBody<T = Record<string, any>> = T | string | Buffer | Readabl
 
 export type RequestNDBody<T = Array<Record<string, any>>> = T | string | string[] | Buffer | ReadableStream
 
-export interface DiagnosticResult<TResponse = unknown, TContext = Context> {
+export interface DiagnosticResult<TResponse = unknown, TContext = unknown> {
   body?: TResponse
   statusCode?: number
   headers?: http.IncomingHttpHeaders
@@ -52,7 +52,7 @@ export interface DiagnosticResult<TResponse = unknown, TContext = Context> {
   }
 }
 
-export interface TransportResult<TResponse = unknown, TContext = Context> extends DiagnosticResult<TResponse, TContext> {
+export interface TransportResult<TResponse = unknown, TContext = unknown> extends DiagnosticResult<TResponse, TContext> {
   body: TResponse
   statusCode: number
   headers: http.IncomingHttpHeaders


### PR DESCRIPTION
- export types from the library root 
- `TContext` falls back to unknown to simplify type declaration;
*without change*:
```typescript
const result: TransportResult<Result, unknown> = await ....

```
*with change*
```typescript
const result: TransportResult<Result> = await ....
```