### PR TITLE
enable type check for d.ts files

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "noFallthroughCasesInSwitch": true,
     "useDefineForClassFields": true,
     "forceConsistentCasingInFileNames": true,
-    "skipLibCheck": true,
+    "skipLibCheck": false,
     "esModuleInterop": true,
     "isolatedModules": true,
     "importHelpers": true,


### PR DESCRIPTION
to avoid a situation when a `d.ts` file contains an invalid type