### PR TITLE
Fix sleep by using custom function

### DIFF
--- a/src/connection/HttpConnection.ts
+++ b/src/connection/HttpConnection.ts
@@ -352,6 +352,6 @@ function isHttpAgentOptions (opts: Record<string, any>): opts is HttpAgentOption
   return true
 }
 
-function sleep (ms: number) {
-  return new Promise((resolve) => setTimeout(resolve, ms))
+async function sleep (ms: number): Promise<unknown> {
+  return await new Promise((resolve) => setTimeout(resolve, ms))
 }


### PR DESCRIPTION
`promisify(setTimeout)` is supported. However this doesn't play well with `jest` that mocks the whole `async` API.

To avoid issues with applications using versions of jest where this issue is not resolved, this PR fixes it by implementing our own `sleep` function