### PR TITLE
Add asStream support

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -38,7 +38,9 @@ export type {
   ConnectionOptions,
   ConnectionRequestParams,
   ConnectionRequestOptions,
-  ConnectionRequestResponse
+  ConnectionRequestOptionsAsStream,
+  ConnectionRequestResponse,
+  ConnectionRequestResponseAsStream
 } from './lib/connection'
 
 export type {
@@ -47,6 +49,7 @@ export type {
 } from './lib/pool'
 
 export type {
+  TransportOptions,
   TransportRequestParams,
   TransportRequestOptions,
   TransportRequestOptionsWithMeta,

--- a/src/connection/BaseConnection.ts
+++ b/src/connection/BaseConnection.ts
@@ -62,13 +62,22 @@ export interface ConnectionRequestOptions {
   context: any
   maxResponseSize?: number
   maxCompressedResponseSize?: number
-  asStream?: boolean
   signal?: AbortSignal
   timeout?: number
 }
 
+export interface ConnectionRequestOptionsAsStream extends ConnectionRequestOptions {
+  asStream: true
+}
+
 export interface ConnectionRequestResponse {
   body: string | Buffer
+  headers: http.IncomingHttpHeaders
+  statusCode: number
+}
+
+export interface ConnectionRequestResponseAsStream {
+  body: ReadableStream
   headers: http.IncomingHttpHeaders
   statusCode: number
 }
@@ -127,7 +136,9 @@ export default class BaseConnection {
   }
 
   /* istanbul ignore next */
-  async request (params: ConnectionRequestParams, options: ConnectionRequestOptions): Promise<ConnectionRequestResponse> {
+  async request (params: ConnectionRequestParams, options: ConnectionRequestOptions): Promise<ConnectionRequestResponse>
+  async request (params: ConnectionRequestParams, options: ConnectionRequestOptionsAsStream): Promise<ConnectionRequestResponseAsStream>
+  async request (params: ConnectionRequestParams, options: any): Promise<any> {
     throw new ConfigurationError('The request method should be implemented by extended classes')
   }
 

--- a/src/connection/index.ts
+++ b/src/connection/index.ts
@@ -26,7 +26,9 @@ export type {
   ConnectionOptions,
   ConnectionRequestParams,
   ConnectionRequestOptions,
-  ConnectionRequestResponse
+  ConnectionRequestOptionsAsStream,
+  ConnectionRequestResponse,
+  ConnectionRequestResponseAsStream
 } from './BaseConnection'
 
 export {

--- a/test/unit/undici-connection.test.ts
+++ b/test/unit/undici-connection.test.ts
@@ -427,37 +427,6 @@ test('Custom headers for connection', async t => {
   server.stop()
 })
 
-// // TODO: add a check that the response is not decompressed
-// test('asStream set to true', t => {
-//   t.plan(2)
-
-//   function handler (req, res) {
-//     res.end('ok')
-//   }
-
-//   buildServer(handler, ({ port }, server) => {
-//     const connection = new Connection({
-//       url: new URL(`http://localhost:${port}`)
-//     })
-//     connection.request({
-//       path: '/hello',
-//       method: 'GET',
-//       asStream: true
-//     }, (err, res) => {
-//       t.error(err)
-
-//       let payload = ''
-//       res.setEncoding('utf8')
-//       res.on('data', chunk => { payload += chunk })
-//       res.on('error', err => t.fail(err))
-//       res.on('end', () => {
-//         t.equal(payload, 'ok')
-//         server.stop()
-//       })
-//     })
-//   })
-// })
-
 // // https://github.com/nodejs/node/commit/b961d9fd83
 test('Should disallow two-byte characters in URL path', async t => {
   t.plan(1)
@@ -1021,5 +990,35 @@ test('Path without intial slash', async t => {
     method: 'GET'
   }, options)
   t.equal(res.body, 'ok')
+  server.stop()
+})
+
+test('as stream', async t => {
+  t.plan(2)
+
+  function handler (req: http.IncomingMessage, res: http.ServerResponse) {
+    res.end('ok')
+  }
+
+  const [{ port }, server] = await buildServer(handler)
+  const connection = new UndiciConnection({
+    url: new URL(`http://localhost:${port}`)
+  })
+  const res = await connection.request({
+    path: '/',
+    method: 'GET'
+  }, {
+    asStream: true,
+    requestId: 42,
+    name: 'test',
+    context: null
+  })
+  t.ok(res.body instanceof Readable)
+  res.body.setEncoding('utf8')
+  let payload = ''
+  for await (const chunk of res.body) {
+    payload += chunk
+  }
+  t.equal(payload, 'ok')
   server.stop()
 })

--- a/test/utils/MockConnection.ts
+++ b/test/utils/MockConnection.ts
@@ -23,16 +23,21 @@ import {
   BaseConnection,
   ConnectionRequestParams,
   ConnectionRequestOptions,
+  ConnectionRequestOptionsAsStream,
   ConnectionRequestResponse,
+  ConnectionRequestResponseAsStream,
   errors
 } from '../../'
+
 const {
   ConnectionError,
   TimeoutError
 } = errors
 
 export class MockConnection extends BaseConnection {
-  request (params: ConnectionRequestParams, options: ConnectionRequestOptions): Promise<ConnectionRequestResponse> {
+  async request (params: ConnectionRequestParams, options: ConnectionRequestOptions): Promise<ConnectionRequestResponse>
+  async request (params: ConnectionRequestParams, options: ConnectionRequestOptionsAsStream): Promise<ConnectionRequestResponseAsStream>
+  async request (params: ConnectionRequestParams, options: any): Promise<any> {
     return new Promise((resolve, reject) => {
       const body = JSON.stringify({ hello: 'world' })
       const statusCode = setStatusCode(params.path)
@@ -49,7 +54,9 @@ export class MockConnection extends BaseConnection {
 }
 
 export class MockConnectionTimeout extends BaseConnection {
-  request (params: ConnectionRequestParams, options: ConnectionRequestOptions): Promise<ConnectionRequestResponse> {
+  async request (params: ConnectionRequestParams, options: ConnectionRequestOptions): Promise<ConnectionRequestResponse>
+  async request (params: ConnectionRequestParams, options: ConnectionRequestOptionsAsStream): Promise<ConnectionRequestResponseAsStream>
+  async request (params: ConnectionRequestParams, options: any): Promise<any> {
     return new Promise((resolve, reject) => {
       process.nextTick(reject, new TimeoutError('Request timed out'))
     })
@@ -57,7 +64,9 @@ export class MockConnectionTimeout extends BaseConnection {
 }
 
 export class MockConnectionError extends BaseConnection {
-  request (params: ConnectionRequestParams, options: ConnectionRequestOptions): Promise<ConnectionRequestResponse> {
+  async request (params: ConnectionRequestParams, options: ConnectionRequestOptions): Promise<ConnectionRequestResponse>
+  async request (params: ConnectionRequestParams, options: ConnectionRequestOptionsAsStream): Promise<ConnectionRequestResponseAsStream>
+  async request (params: ConnectionRequestParams, options: any): Promise<any> {
     return new Promise((resolve, reject) => {
       process.nextTick(reject, new ConnectionError('kaboom'))
     })
@@ -65,7 +74,9 @@ export class MockConnectionError extends BaseConnection {
 }
 
 export class MockConnectionSniff extends BaseConnection {
-  request (params: ConnectionRequestParams, options: ConnectionRequestOptions): Promise<ConnectionRequestResponse> {
+  async request (params: ConnectionRequestParams, options: ConnectionRequestOptions): Promise<ConnectionRequestResponse>
+  async request (params: ConnectionRequestParams, options: ConnectionRequestOptionsAsStream): Promise<ConnectionRequestResponseAsStream>
+  async request (params: ConnectionRequestParams, options: any): Promise<any> {
     return new Promise((resolve, reject) => {
       const sniffResult = {
         nodes: {
@@ -106,7 +117,9 @@ export function buildMockConnection (opts: onRequestMock) {
   assert(opts.onRequest, 'Missing required onRequest option')
 
   class MockConnection extends BaseConnection {
-    request (params: ConnectionRequestParams, options: ConnectionRequestOptions): Promise<ConnectionRequestResponse> {
+    async request (params: ConnectionRequestParams, options: ConnectionRequestOptions): Promise<ConnectionRequestResponse>
+    async request (params: ConnectionRequestParams, options: ConnectionRequestOptionsAsStream): Promise<ConnectionRequestResponseAsStream>
+    async request (params: ConnectionRequestParams, options: any): Promise<any> {
       return new Promise((resolve, reject) => {
         let { body, statusCode, headers } = opts.onRequest(params)
         if (typeof body !== 'string' && !(body instanceof Buffer)) {


### PR DESCRIPTION
With this option, the transport will return a readable stream directly from the HTTP layer, it won't try to parse it or decompress it.
The response size check won't be executed.

```ts
import { Readable } from 'stream'
import {
  Transport,
  WeightedConnectionPool,
  UndiciConnection
} from '@elastic/transport'

const pool = new WeightedConnectionPool({ Connection: UndiciConnection })
pool.addConnection('http://localhost:9200')
const transport = new Transport({ connectionPool: pool })

const body = await transport.request<Readable>({
  method: 'GET',
  path: '/'
}, {
  asStream: true
})

body.setEncoding('utf8')
let payload = ''
for await (const chunk of body) {
  payload += chunk
}
console.log(payload)
```