### PR TITLE
Add request duration to diagnostic metadata

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,7 @@ export interface DiagnosticResult<TResponse = unknown, TContext = unknown> {
       options: TransportRequestOptions
       id: any
     }
+    duration: number
     connection: Connection | null
     attempts: number
     aborted: boolean

--- a/test/acceptance/observability.test.ts
+++ b/test/acceptance/observability.test.ts
@@ -425,3 +425,32 @@ test('event.meta.request.params.body should be a string', t => {
     .then(() => t.pass('ok'))
     .catch(err => t.fail(err))
 })
+
+test('request duration', t => {
+  t.plan(7)
+
+  const client = new TestClient({
+    node: 'http://localhost:9200',
+    Connection: MockConnection
+  })
+
+  client.diagnostic.on(events.SERIALIZATION, (err, event) => {
+    t.error(err)
+    t.equal(event?.meta.duration, -1)
+  })
+
+  client.diagnostic.on(events.REQUEST, (err, event) => {
+    t.error(err)
+    t.equal(event?.meta.duration, -1)
+  })
+
+  client.diagnostic.on(events.RESPONSE, (err, event) => {
+    t.error(err)
+    // @ts-expect-error
+    t.ok(event?.meta.duration >= 0)
+  })
+
+  client.request({ method: 'POST', path: '/', body: { foo: 'bar' } })
+    .then(() => t.pass('ok'))
+    .catch(err => t.fail(err))
+})


### PR DESCRIPTION
As titled.
Now 100% convinced this should live in the transport, as it can be obtained with observability events and it causes a minor slowdown in performances.

Code used for benchmarks:
```js
'use strict'

const http = require('http')

const server = http.createServer((req, res) => {
  res.writeHead(200, {
    'content-type': 'application/json'
  })
  res.end('{"hello":"world"}')
})

server.listen(3000, async () => {
  console.log('listening')
})
```

```js
'use strict'

const { Transport, WeightedConnectionPool, UndiciConnection } = require('./')

const pool = new WeightedConnectionPool({ Connection: UndiciConnection })
pool.addConnection('http://localhost:3000')
const transport = new Transport({ connectionPool: pool })

async function run () {
  for (let i = 0; i < 1000; i++) {
    await transport.request({ method: 'GET', path: '/' })
  }
}

run().catch(err => {
  console.log(err)
  process.exit(1)
})
```

Results:
```
# this branch
  Time (mean ± σ):     438.2 ms ±  51.3 ms    [User: 470.0 ms, System: 83.4 ms]
  Range (min … max):   389.0 ms … 521.6 ms    10 runs

# main branch
Benchmark 1: node bench.js
  Time (mean ± σ):     405.5 ms ±  35.3 ms    [User: 451.2 ms, System: 77.6 ms]
  Range (min … max):   366.6 ms … 478.9 ms    10 runs
```
The benchmark has been taken with [hyperfine](https://github.com/sharkdp/hyperfine).