### PR TITLE
Drop Node.js v12

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x, 17.x]
+        node-version: [14.x, 16.x, 17.x]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ npm install @elastic/transport
 
 ### Node.js support
 
-NOTE: The minimum supported version of Node.js is `v12`.
+NOTE: The minimum supported version of Node.js is `v14`.
 
 The client versioning follows the Elastc Stack versioning, this means that
 major, minor, and patch releases are done following a precise schedule that
@@ -36,7 +36,9 @@ of `^7.10.0`).
 | Node.js Version | Node.js EOL date | End of support         |
 | --------------- |------------------| ---------------------- |
 | `8.x`           | `December 2019`  | `7.11` (early 2021)    |       
-| `10.x`          | `April 2021`      | `7.12` (mid 2021)      |     
+| `10.x`          | `April 2021`     | `7.12` (mid 2021)      |
+| `12.x`          | `April 2022`     | `8.2` (early 2022)     |
+| `14.x`          | `April 2023`     | `8.8` (early 2023)     | 
 
 ## API
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/elastic/elastic-transport-js#readme",
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "devDependencies": {
     "@sinonjs/fake-timers": "github:sinonjs/fake-timers#0bfffc1",


### PR DESCRIPTION
As titled.

Related: https://github.com/elastic/elasticsearch-js/pull/1670