### PR TITLE
Add support for custom undici agents

### DIFF
--- a/src/connection/UndiciConnection.ts
+++ b/src/connection/UndiciConnection.ts
@@ -59,8 +59,8 @@ export default class Connection extends BaseConnection {
       throw new ConfigurationError('Undici connection can\'t work with proxies')
     }
 
-    if (typeof opts.agent === 'function' || typeof opts.agent === 'boolean') {
-      throw new ConfigurationError('Undici connection agent options can\'t be a function or a boolean')
+    if (typeof opts.agent === 'boolean') {
+      throw new ConfigurationError('Undici connection agent options can\'t be a boolean')
     }
 
     if (opts.agent != null && !isUndiciAgentOptions(opts.agent)) {
@@ -110,7 +110,12 @@ export default class Connection extends BaseConnection {
       undiciOptions.connect = this.tls as buildConnector.BuildOptions
     }
 
-    this.pool = new Pool(this.url.toString(), undiciOptions)
+    if (typeof opts.agent === 'function') {
+      // @ts-expect-error
+      this.pool = opts.agent(opts)
+    } else {
+      this.pool = new Pool(this.url.toString(), undiciOptions)
+    }
   }
 
   async request (params: ConnectionRequestParams, options: ConnectionRequestOptions): Promise<ConnectionRequestResponse>

--- a/test/acceptance/mock-undici.test.ts
+++ b/test/acceptance/mock-undici.test.ts
@@ -1,0 +1,79 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { test } from 'tap'
+import { MockAgent } from 'undici'
+import { UndiciConnection, errors } from '../..'
+import { TestClient } from '../utils'
+
+test('Mocking undici with undici\'s mocking utility should work', async t => {
+  t.plan(1)
+
+  const mockAgent = new MockAgent()
+  const mockPool = mockAgent.get('http://test-cluster:9200')
+
+  const mockResponse = {
+    _index: 'test-index',
+    _type: '_doc',
+    _id: 'TEST_ID',
+    _version: 1,
+    _seq_no: 0,
+    _primary_term: 1,
+    found: true,
+    _source: {}
+  }
+
+  mockPool
+    .intercept({ path: '/my-index/_doc/my-id', method: 'GET' })
+    .reply(200, mockResponse, {
+      headers: {
+        'x-elastic-product': 'Elasticsearch',
+        'content-type': 'application/json'
+      }
+    })
+
+  const client = new TestClient({
+    node: 'http://test-cluster:9200',
+    Connection: UndiciConnection,
+    agent: () => mockPool
+  })
+
+  const response = await client.request({ method: 'GET', path: '/my-index/_doc/my-id' })
+  t.same(response, mockResponse)
+})
+
+test('Mock not found', async t => {
+  t.plan(2)
+
+  const mockAgent = new MockAgent()
+  const mockPool = mockAgent.get('http://test-cluster:9200')
+
+  const client = new TestClient({
+    node: 'http://test-cluster:9200',
+    Connection: UndiciConnection,
+    agent: () => mockPool
+  })
+
+  try {
+    await client.request({ method: 'GET', path: '/my-index/_doc/my-id' })
+  } catch (err: any) {
+    t.ok(err instanceof errors.ConnectionError)
+    t.equal(err.message, 'getaddrinfo ENOTFOUND test-cluster')
+  }
+})

--- a/test/acceptance/mock-undici.test.ts
+++ b/test/acceptance/mock-undici.test.ts
@@ -74,6 +74,6 @@ test('Mock not found', async t => {
     await client.request({ method: 'GET', path: '/my-index/_doc/my-id' })
   } catch (err: any) {
     t.ok(err instanceof errors.ConnectionError)
-    t.equal(err.message, 'getaddrinfo ENOTFOUND test-cluster')
+    t.ok(['getaddrinfo ENOTFOUND test-cluster', 'getaddrinfo EAI_AGAIN test-cluster'].includes(err.message))
   }
 })

--- a/test/unit/undici-connection.test.ts
+++ b/test/unit/undici-connection.test.ts
@@ -833,7 +833,7 @@ test('Connection error', async t => {
 })
 
 test('Throw if detects http agent options', async t => {
-  t.plan(3)
+  t.plan(2)
 
   try {
     new UndiciConnection({
@@ -841,15 +841,6 @@ test('Throw if detects http agent options', async t => {
       agent: {
         keepAlive: false
       }
-    })
-  } catch (err: any) {
-    t.ok(err instanceof ConfigurationError)
-  }
-
-  try {
-    new UndiciConnection({
-      url: new URL('http://localhost:9200'),
-      agent: () => new http.Agent()
     })
   } catch (err: any) {
     t.ok(err instanceof ConfigurationError)


### PR DESCRIPTION
This allows using undici's mock utilities.
This library won't work with `setGlobalDispatcher` because it uses the low-level `Pool` API.

/cc @mcollina @ronag 

Related: https://github.com/elastic/elasticsearch-js/issues/1674

Wait for https://github.com/nodejs/undici/issues/1331 before merging.