### PR TITLE
Upgrade `undici` dependency (`5.1.1` → `5.5.1`).

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "ms": "^2.1.3",
     "secure-json-parse": "^2.4.0",
     "tslib": "^2.4.0",
-    "undici": "^5.1.1"
+    "undici": "^5.5.1"
   },
   "tap": {
     "ts": true,

--- a/src/Transport.ts
+++ b/src/Transport.ts
@@ -473,7 +473,7 @@ export default class Transport {
         result.headers = headers
 
         if (this[kProductCheck] != null && headers['x-elastic-product'] !== this[kProductCheck] && statusCode >= 200 && statusCode < 300) {
-          throw new ProductNotSupportedError(this[kProductCheck] as string, result)
+          throw new ProductNotSupportedError(this[kProductCheck], result)
         }
 
         if (options.asStream === true) {


### PR DESCRIPTION
## Summary

Upgrade `undici` dependency (`5.1.1` → `5.5.1`).

Change log: https://github.com/nodejs/undici/releases
Change set: https://github.com/nodejs/undici/compare/v5.1.1...v5.5.1

__Note to reviewers:__ It doesn't seem there were any breaking changes since `v5.1.1`, `npm test` doesn't complain either. We (Kibana) are particularly interested in upgrade to `v5.1.1` even though we're not _yet_ affected by the issue this release had fixed (we don't seem to use `ProxyAgent` from `undici` anywhere).