### PR TITLE
Check max response length even when the content-length header is not present

### DIFF
--- a/src/Transport.ts
+++ b/src/Transport.ts
@@ -473,8 +473,10 @@ export default class Transport {
         result.headers = headers
 
         if (this[kProductCheck] != null && headers['x-elastic-product'] !== this[kProductCheck] && statusCode >= 200 && statusCode < 300) {
-          // @ts-expect-error
+          /* eslint-disable @typescript-eslint/prefer-ts-expect-error */
+          // @ts-ignore
           throw new ProductNotSupportedError(this[kProductCheck], result)
+          /* eslint-enable @typescript-eslint/prefer-ts-expect-error */
         }
 
         if (options.asStream === true) {

--- a/src/Transport.ts
+++ b/src/Transport.ts
@@ -473,6 +473,7 @@ export default class Transport {
         result.headers = headers
 
         if (this[kProductCheck] != null && headers['x-elastic-product'] !== this[kProductCheck] && statusCode >= 200 && statusCode < 300) {
+          // @ts-expect-error
           throw new ProductNotSupportedError(this[kProductCheck], result)
         }
 


### PR DESCRIPTION
Usually, the `'transfer-encoding': 'chunked'` header is used for streams, and the Client expects the user to enable `asStream: true` to handle on their own the specific case.
This change expands the use of the `maxResponseSize` and `maxCompressedResponseSize` to work even if the `content-type` header is not set.

Fixes: #56
