### PR TITLE
Test with node v19; fix test with new keep-alive default in node v19

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [14.x, 16.x, 18.x, 19.x]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:

--- a/src/connection/UndiciConnection.ts
+++ b/src/connection/UndiciConnection.ts
@@ -181,6 +181,7 @@ export default class Connection extends BaseConnection {
       }
     }
 
+    // @ts-expect-error Assume header is not string[] for now.
     const contentEncoding = (response.headers['content-encoding'] ?? '').toLowerCase()
     const isCompressed = contentEncoding.includes('gzip') || contentEncoding.includes('deflate') // eslint-disable-line
     const isVectorTile = (response.headers['content-type'] ?? '').includes('application/vnd.mapbox-vector-tile')


### PR DESCRIPTION
Node v19 has made keep-alive on by default, so using `agent: false` no longer disables keep-alive. I've fixed the test to handle that, so tests pass with node >= v19.


---

This also works around the following lint error:

```
src/connection/UndiciConnection.ts:184:74 - error TS2339: Property 'toLowerCase' does not exist on type 'string | string[]'.
  Property 'toLowerCase' does not exist on type 'string[]'.

184     const contentEncoding = (response.headers['content-encoding'] ?? '').toLowerCase()
```

I'm happy to drop that `@ts-expect-error` in favour of a more reliable fix there.