### PR TITLE
Skip adding new nodes that aren't ready yet

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/transport",
-  "version": "8.3.3",
+  "version": "8.3.4",
   "description": "Transport classes and utilities shared among Node.js Elastic client libraries",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/pool/BaseConnectionPool.ts
+++ b/src/pool/BaseConnectionPool.ts
@@ -254,6 +254,9 @@ export default class BaseConnectionPool {
 
     for (let i = 0, len = ids.length; i < len; i++) {
       const node = nodes[ids[i]]
+      // newly-added nodes do not have http assigned yet, so skip
+      if (node.http === undefined) continue
+
       // If there is no protocol in
       // the `publish_address` new URL will throw
       // the publish_address can have two forms:

--- a/test/unit/base-connection.pool.test.ts
+++ b/test/unit/base-connection.pool.test.ts
@@ -266,6 +266,28 @@ test('API', t => {
       t.end()
     })
 
+    t.test('Should skip nodes that do not have an http property yet', t => {
+      const pool = new BaseConnectionPool({ Connection: HttpConnection })
+      const nodes = {
+        a1: {
+          http: {
+            publish_address: '127.0.0.1:9200'
+          },
+          roles: ['master', 'data', 'ingest']
+        },
+        a2: {
+          roles: ['master', 'data', 'ingest']
+        }
+      }
+
+      t.same(pool.nodesToHost(nodes, 'http:'), [{
+        url: new URL('http://127.0.0.1:9200'),
+        id: 'a1'
+      }])
+
+      t.end()
+    })
+
     t.end()
   })
 


### PR DESCRIPTION
When nodes are just added to a cluster, they may not have an `http` object yet. Skipping over those ensures the hosts list only contains nodes that can actually take a connection.

Should help resolve https://github.com/elastic/elasticsearch-js/issues/1230.
