### PR TITLE
Dispatch events to AbortSignal properly

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [14.x, 16.x, 18.x, 19.x, 20.x]
+        node-version: [16.x, 18.x, 19.x, 20.x]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ npm install @elastic/transport
 
 ### Node.js support
 
-NOTE: The minimum supported version of Node.js is `v14`.
+NOTE: The minimum supported version of Node.js is `v16`.
 
 The client versioning follows the Elastc Stack versioning, this means that
 major, minor, and patch releases are done following a precise schedule that
@@ -23,9 +23,7 @@ often does not coincide with the [Node.js release](https://nodejs.org/en/about/r
 To avoid support insecure and unsupported versions of Node.js, the
 client **will drop the support of EOL versions of Node.js between minor releases**.
 Typically, as soon as a Node.js version goes into EOL, the client will continue
-to support that version for at least another minor release. If you are using the client
-with a version of Node.js that will be unsupported soon, you will see a warning
-in your logs (the client will start logging the warning with two minors in advance).
+to support that version for at least another minor release.
 
 Unless you are **always** using a supported version of Node.js, 
 we recommend defining the client dependency in your

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/elastic/elastic-transport-js#readme",
   "engines": {
-    "node": ">=14"
+    "node": ">=16"
   },
   "devDependencies": {
     "@sinonjs/fake-timers": "github:sinonjs/fake-timers#0bfffc1",

--- a/src/connection/UndiciConnection.ts
+++ b/src/connection/UndiciConnection.ts
@@ -141,7 +141,8 @@ export default class Connection extends BaseConnection {
       timeoutId = setTimeout(() => {
         timedout = true
         if (options.signal != null) {
-          options.signal.dispatchEvent('abort')
+          // @ts-expect-error Event is a Node.js global
+          options.signal.dispatchEvent(new Event('abort'))
         } else {
           this[kEmitter].emit('abort')
         }

--- a/test/acceptance/events-order.test.ts
+++ b/test/acceptance/events-order.test.ts
@@ -19,7 +19,6 @@
 
 import { test } from 'tap'
 import * as http from 'http'
-import { AbortController } from 'node-abort-controller'
 import {
   HttpConnection,
   UndiciConnection,

--- a/test/unit/http-connection.test.ts
+++ b/test/unit/http-connection.test.ts
@@ -26,7 +26,7 @@ import { gzipSync, deflateSync } from 'zlib'
 import { Readable } from 'stream'
 import hpagent from 'hpagent'
 import intoStream from 'into-stream'
-import { AbortController } from 'node-abort-controller'
+import { AbortController as LegacyAbortController } from 'node-abort-controller'
 import { buildServer } from '../utils'
 import { HttpConnection, errors, ConnectionOptions } from '../../'
 import net from "net";
@@ -1245,7 +1245,10 @@ test('as stream', async t => {
 test('Cleanup abort listener', async t => {
   t.plan(2)
 
-  const controller = new AbortController()
+  // uses legacy node-abort-controller polyfill package because the global
+  // AbortController's signal does not let expose an `eventEmitter` property for
+  // us to inspect, but the legacy package does!
+  const controller = new LegacyAbortController()
 
   function handler (req: http.IncomingMessage, res: http.ServerResponse) {
     // @ts-expect-error

--- a/test/unit/transport.test.ts
+++ b/test/unit/transport.test.ts
@@ -28,7 +28,6 @@ import os from 'os'
 import { Readable } from 'stream'
 import intoStream from 'into-stream'
 import * as http from 'http'
-import { AbortController } from 'node-abort-controller'
 import {
   Transport,
   Serializer,

--- a/test/unit/undici-connection.test.ts
+++ b/test/unit/undici-connection.test.ts
@@ -24,7 +24,6 @@ import buffer from 'buffer'
 import { gzipSync, deflateSync } from 'zlib'
 import { Readable } from 'stream'
 import intoStream from 'into-stream'
-import { AbortController } from 'node-abort-controller'
 import { buildServer } from '../utils'
 import { UndiciConnection, errors, ConnectionOptions } from '../../'
 
@@ -221,6 +220,7 @@ test('Timeout support / 4', async t => {
       timeout: 50,
       ...options
     })
+    t.fail('Timeout was not reached')
   } catch (err: any) {
     t.ok(err instanceof TimeoutError)
     t.equal(err.message, 'Request timed out')
@@ -448,7 +448,7 @@ test('Should disallow two-byte characters in URL path', async t => {
 })
 
 test('Abort a request syncronously', async t => {
-  t.plan(1)
+  t.plan(2)
 
   function handler (req: http.IncomingMessage, res: http.ServerResponse) {
     t.fail('The server should not be contacted')
@@ -469,6 +469,7 @@ test('Abort a request syncronously', async t => {
     ...options
   }).catch(err => {
     t.ok(err instanceof RequestAbortedError)
+    t.ok(controller.signal.aborted, 'Signal should be aborted')
     server.stop()
   })
 


### PR DESCRIPTION
This implementation was assuming the use of the legacy [node-abort-controller](https://www.npmjs.com/package/node-abort-controller) package instead of the global `AbortController`. The legacy package supports dispatching strings as events, but the `AbortSignal` as implemented in the Node.js API from 15.x forward only accepts `Event` objects.

This also explicitly drops support for Node.js 14. elasticsearch-js dropped it a while ago, but it didn't need to get dropped on the transport until now.

See https://github.com/elastic/elastic-transport-js/issues/73.
