### PR TITLE
fix: increase default value of max event listeners

### DIFF
--- a/src/connection/BaseConnection.ts
+++ b/src/connection/BaseConnection.ts
@@ -46,6 +46,7 @@ export interface ConnectionOptions {
   agent?: HttpAgentOptions | UndiciAgentOptions | agentFn | boolean
   proxy?: string | URL
   caFingerprint?: string
+  maxEventListeners?: number
 }
 
 export interface ConnectionRequestParams {
@@ -92,6 +93,7 @@ export default class BaseConnection {
   resurrectTimeout: number
   _openRequests: number
   weight: number
+  maxEventListeners: number
   [kStatus]: string
   [kCaFingerprint]: string | null
   [kDiagnostic]: Diagnostic
@@ -111,10 +113,10 @@ export default class BaseConnection {
     this.resurrectTimeout = 0
     this.weight = 0
     this._openRequests = 0
+    this.maxEventListeners = opts.maxEventListeners ?? 100
     this[kStatus] = opts.status ?? BaseConnection.statuses.ALIVE
     this[kDiagnostic] = opts.diagnostic ?? new Diagnostic()
     this[kCaFingerprint] = opts.caFingerprint ?? null
-
     if (!['http:', 'https:'].includes(this.url.protocol)) {
       throw new ConfigurationError(`Invalid protocol: '${this.url.protocol}'`)
     }

--- a/src/connection/UndiciConnection.ts
+++ b/src/connection/UndiciConnection.ts
@@ -68,6 +68,7 @@ export default class Connection extends BaseConnection {
     }
 
     this[kEmitter] = new EventEmitter()
+    this[kEmitter].setMaxListeners(this.maxEventListeners)
     const undiciOptions: Pool.Options = {
       keepAliveTimeout: 600e3,
       keepAliveMaxTimeout: 600e3,

--- a/test/unit/undici-connection.test.ts
+++ b/test/unit/undici-connection.test.ts
@@ -1059,6 +1059,26 @@ test('Path without intial slash', async t => {
   server.stop()
 })
 
+test('Should increase number of max event listeners', async t => {
+  t.plan(1)
+
+  function handler (req: http.IncomingMessage, res: http.ServerResponse) {
+    res.end('ok')
+  }
+
+  const [{ port }, server] = await buildServer(handler, { secure: true })
+  const connection = new UndiciConnection({
+    url: new URL(`https://localhost:${port}`),
+    maxEventListeners: 100,
+  })
+  const res = await connection.request({
+    path: '/hello',
+    method: 'GET'
+  }, options)
+  t.equal(res.body, 'ok')
+  server.stop()
+})
+
 test('as stream', async t => {
   t.plan(2)
 


### PR DESCRIPTION
<!--

Hello there!

Thank you for opening a pull request!
Please remember to always tag the relative issue (if any) and give a brief explanation on what your changes are doing.

If you are patching a security issue, please take a look at https://www.elastic.co/community/security

Finally, please make sure you have signed the Contributor License Agreement
We are not asking you to assign copyright to us, but to give us the right to distribute your code without restriction.
We ask this of all contributors in order to assure our users of the origin and continuing existence of the code. You only need to sign the CLA once.
https://www.elastic.co/contributor-agreement/

Happy coding!

-->

issue: https://github.com/elastic/elastic-transport-js/issues/63

Increased default value of max event listeners to 100 if not specified on options.
