### PR TITLE
Added Array.isArray check during redaction

### DIFF
--- a/src/security.ts
+++ b/src/security.ts
@@ -45,7 +45,7 @@ export function redactObject (obj: Record<string, any>, additionalKeys: string[]
         value = `${value.origin}${value.pathname}${value.search}`
       }
 
-      if (typeof value === 'object' && value !== null) {
+      if (typeof value === 'object' && !Array.isArray(value) && value !== null) {
         if (seen.get(value) !== true) {
           // if this Object hasn't been seen, recursively redact it
           seen.set(value, true)

--- a/test/unit/errors.test.ts
+++ b/test/unit/errors.test.ts
@@ -165,3 +165,26 @@ test('redact extra keys when passed', t => {
 
   t.end()
 })
+
+test('redaction does not transform array properties into objects', t => {
+  const errResponse = new errors.ResponseError({
+    body: {
+      error: {
+        root_cause: [
+          {
+            type: 'index_not_found_exception',
+            reason: 'no such index [poop]',
+          },
+        ],
+      },
+      status: 404,
+    },
+    statusCode: 404,
+    headers: {},
+    warnings: [],
+    meta: {} as any,
+  });
+
+  t.equal(Array.isArray(errResponse.body.error.root_cause), true)
+  t.end()
+})


### PR DESCRIPTION
This PR fixes https://github.com/elastic/elasticsearch-js/issues/2128 issue. The issue was related to the conversion of property array into object due to this check:
```js
if (typeof value === 'object' && value !== null) {
  // ...
}
```
Since `typeof` of  an Array is an `object` in Javascript (see [here](https://stackoverflow.com/questions/12996871/why-does-typeof-array-with-objects-return-object-and-not-array)) the solution for removing Array in this condition is to use `Array.isArray()`, as follows:
```js
if (typeof value === 'object' && !Array.isArray(value) && value !== null) {
  // ..
}
```