### PR TITLE
Tests to ensure redaction does not leak back to original data

### DIFF
--- a/test/unit/errors.test.ts
+++ b/test/unit/errors.test.ts
@@ -188,3 +188,12 @@ test('redaction does not transform array properties into objects', t => {
   t.equal(Array.isArray(errResponse.body.error.root_cause), true)
   t.end()
 })
+
+test('redaction does leak back to original object', t => {
+  const diags = makeDiagnostics()
+  diags.forEach(diag => {
+    const err = new errors.TimeoutError('timeout', diag)
+    t.not(err?.meta?.headers?.authorization, diag.headers?.authorization)
+  })
+  t.end()
+})


### PR DESCRIPTION
There was some concern that redaction of diagnostic data in errors was not deep-cloning, causing redactions to be applied back to original request/response data. Added tests to verify that is not the case.

cc @ezimuel
