### PR TITLE
Redaction should recurse into arrays

### DIFF
--- a/src/security.ts
+++ b/src/security.ts
@@ -45,15 +45,20 @@ export function redactObject (obj: Record<string, any>, additionalKeys: string[]
         value = `${value.origin}${value.pathname}${value.search}`
       }
 
-      if (typeof value === 'object' && !Array.isArray(value) && value !== null) {
-        if (seen.get(value) !== true) {
-          // if this Object hasn't been seen, recursively redact it
-          seen.set(value, true)
-          value = doRedact(value)
+      if (typeof value === 'object' && value !== null) {
+        if (Array.isArray(value)) {
+          // if it's an array, redact each item
+          value = value.map(v => doRedact(v))
         } else {
-          // if it has been seen, set the value that goes in newObj to null
-          // this is what prevents the circular references
-          value = null
+          if (seen.get(value) !== true) {
+            // if this Object hasn't been seen, recursively redact it
+            seen.set(value, true)
+            value = doRedact(value)
+          } else {
+            // if it has been seen, set the value that goes in newObj to null
+            // this is what prevents the circular references
+            value = null
+          }
         }
       }
 

--- a/test/unit/security.test.ts
+++ b/test/unit/security.test.ts
@@ -192,5 +192,18 @@ test('redactObject', t => {
     t.equal(result.url, 'http://foo.com/path/to/endpoint?query=true')
   })
 
+  t.test('properly recurses into arrays', t => {
+    t.plan(2)
+    const result = redactObject({
+      foo: [
+        { authorization: 'foo' },
+        { password: 'bar' },
+      ]
+    })
+
+    t.notMatch(result.foo[0].authorization, 'foo')
+    t.notMatch(result.foo[1].password, 'bar')
+  })
+
   t.end()
 })


### PR DESCRIPTION
Array logic added in https://github.com/elastic/elastic-transport-js/pull/83 addressed arrays by skipping over them, treating them like primitive values. This updates the logic to recurse down into each array item.
