### PR TITLE
Fix Undici abort test to work with 6.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "ms": "^2.1.3",
     "secure-json-parse": "^2.4.0",
     "tslib": "^2.4.0",
-    "undici": "^6.7.0"
+    "undici": "^6.12.0"
   },
   "tap": {
     "ts": true,

--- a/test/unit/undici-connection.test.ts
+++ b/test/unit/undici-connection.test.ts
@@ -513,8 +513,12 @@ test('Abort with a slow body', async t => {
   t.plan(1)
 
   const controller = new AbortController()
+  function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
+    res.end('ok')
+  }
+  const [{ port }, server] = await buildServer(handler)
   const connection = new UndiciConnection({
-    url: new URL('https://localhost:9200')
+    url: new URL(`http://localhost:${port}`)
   })
 
   const slowBody = new Readable({
@@ -540,6 +544,7 @@ test('Abort with a slow body', async t => {
   } catch (err: any) {
     t.ok(err instanceof RequestAbortedError)
   }
+  server.stop()
 })
 
 // The nodejs http agent will try to wait for the whole


### PR DESCRIPTION
Test no longer likes being run against a nonexistent server. Was
getting ECONNREFUSED instead of an abort.

Most likely caused by one of the following changes to Undici added in
6.12.0:

https://github.com/nodejs/undici/pull/3053
https://github.com/nodejs/undici/pull/3056
