### PR TITLE
Refactor request abort handling

### DIFF
--- a/src/Serializer.ts
+++ b/src/Serializer.ts
@@ -43,6 +43,9 @@ export default class Serializer {
     }
   }
 
+  /**
+   * Serializes a record into a JSON string
+   */
   serialize (object: Record<string, any>): string {
     debug('Serializing', object)
     let json
@@ -54,6 +57,9 @@ export default class Serializer {
     return json
   }
 
+  /**
+   * Given a string, attempts to parse it from raw JSON into an object
+   */
   deserialize<T = unknown> (json: string): T {
     debug('Deserializing', json)
     let object
@@ -66,6 +72,9 @@ export default class Serializer {
     return object
   }
 
+  /**
+   * Serializes an array of records into an ndjson string
+   */
   ndserialize (array: Array<Record<string, any> | string>): string {
     debug('ndserialize', array)
     if (!Array.isArray(array)) {

--- a/src/pool/BaseConnectionPool.ts
+++ b/src/pool/BaseConnectionPool.ts
@@ -144,8 +144,8 @@ export default class BaseConnectionPool {
   /**
    * Adds a new connection to the pool.
    *
-   * @param {object|string} host
-   * @returns {ConnectionPool}
+   * @param connection Connection options, or the URL of a node
+   * @returns This ConnectionPool instance
    */
   addConnection (connection: AddConnectionOptions | AddConnectionOptions[]): this {
     if (Array.isArray(connection)) {
@@ -160,10 +160,10 @@ export default class BaseConnectionPool {
   }
 
   /**
-   * Removes a new connection to the pool.
+   * Removes a connection from the pool.
    *
-   * @param {object} connection
-   * @returns {ConnectionPool}
+   * @param connection The connection to remove
+   * @returns This ConnectionPool instance
    */
   removeConnection (connection: Connection): this {
     debug('Removing connection', connection)

--- a/test/unit/http-connection.test.ts
+++ b/test/unit/http-connection.test.ts
@@ -219,7 +219,7 @@ test('Timeout support / 1', async t => {
       method: 'GET'
     }, options)
   } catch (err: any) {
-    t.ok(err instanceof TimeoutError)
+    t.ok(err instanceof TimeoutError, `Not a TimeoutError: ${err}`)
   }
   server.stop()
 })
@@ -245,7 +245,7 @@ test('Timeout support / 2', async t => {
       ...options
     })
   } catch (err: any) {
-    t.ok(err instanceof TimeoutError)
+    t.ok(err instanceof TimeoutError, `Not a TimeoutError: ${err}`)
   }
   server.stop()
 })
@@ -272,7 +272,7 @@ test('Timeout support / 3', async t => {
       ...options
     })
   } catch (err: any) {
-    t.ok(err instanceof TimeoutError)
+    t.ok(err instanceof TimeoutError, `Not a TimeoutError: ${err}`)
   }
   server.stop()
 })
@@ -538,7 +538,7 @@ test('Port handling', t => {
 test('Abort a request syncronously', async t => {
   t.plan(1)
 
-  function handler (req: http.IncomingMessage, res: http.ServerResponse) {
+  function handler (_req: http.IncomingMessage, _res: http.ServerResponse) {
     t.fail('The server should not be contacted')
   }
 
@@ -549,16 +549,13 @@ test('Abort a request syncronously', async t => {
   })
 
   const controller = new AbortController()
-  connection.request({
-    path: '/hello',
-    method: 'GET'
-  }, {
-    signal: controller.signal,
-    ...options
-  }).catch(err => {
-    t.ok(err instanceof RequestAbortedError)
-    server.stop()
-  })
+  connection.request(
+    { path: '/hello', method: 'GET' },
+    { signal: controller.signal, ...options })
+    .catch(err => {
+      t.ok(err instanceof RequestAbortedError, `Not a RequestAbortedError: ${err}`)
+      server.stop()
+    })
 
   controller.abort()
   await connection.close()
@@ -567,7 +564,7 @@ test('Abort a request syncronously', async t => {
 test('Abort a request asyncronously', async t => {
   t.plan(1)
 
-  function handler (req: http.IncomingMessage, res: http.ServerResponse) {
+  function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
     // might be called or not
     res.end('ok')
   }
@@ -589,7 +586,7 @@ test('Abort a request asyncronously', async t => {
       ...options
     })
   } catch (err: any) {
-    t.ok(err instanceof RequestAbortedError)
+    t.ok(err instanceof RequestAbortedError, `Not a RequestAbortedError: ${err}`)
   }
 
   await connection.close()
@@ -656,11 +653,10 @@ test('Abort with a slow body', async t => {
   const controller = new AbortController()
   const connection = new HttpConnection({
     url: new URL('https://localhost:9200'),
-    proxy: 'http://localhost:8080'
   })
 
   const slowBody = new Readable({
-    read (size: number) {
+    read (_size: number) {
       setTimeout(() => {
         this.push('{"size":1, "query":{"match_all":{}}}')
         this.push(null) // EOF
@@ -680,7 +676,7 @@ test('Abort with a slow body', async t => {
       ...options
     })
   } catch (err: any) {
-    t.ok(err instanceof RequestAbortedError)
+    t.ok(err instanceof RequestAbortedError, `Not a RequestAbortedError: ${err}`)
   }
 })
 
@@ -690,7 +686,7 @@ test('Abort with a slow body', async t => {
 test('Bad content length', async t => {
   t.plan(2)
 
-  function handler (req: http.IncomingMessage, res: http.ServerResponse) {
+  function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
     const body = JSON.stringify({ hello: 'world' })
     res.setHeader('Content-Type', 'application/json;utf=8')
     res.setHeader('Content-Length', body.length + '')
@@ -707,7 +703,7 @@ test('Bad content length', async t => {
       method: 'GET'
     }, options)
   } catch (err: any) {
-    t.ok(err instanceof ConnectionError)
+    t.ok(err instanceof ConnectionError, `Not a ConnectionError: ${err}`)
     t.equal(err.message, 'Response aborted while reading the body')
   }
   server.stop()
@@ -716,7 +712,7 @@ test('Bad content length', async t => {
 test('Socket destryed while reading the body', async t => {
   t.plan(2)
 
-  function handler (req: http.IncomingMessage, res: http.ServerResponse) {
+  function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
     const body = JSON.stringify({ hello: 'world' })
     res.setHeader('Content-Type', 'application/json;utf=8')
     res.setHeader('Content-Length', body.length + '')
@@ -736,7 +732,7 @@ test('Socket destryed while reading the body', async t => {
       method: 'GET'
     }, options)
   } catch (err: any) {
-    t.ok(err instanceof ConnectionError)
+    t.ok(err instanceof ConnectionError, `Not a ConnectionError: ${err}`)
     t.equal(err.message, 'Response aborted while reading the body')
   }
   server.stop()
@@ -787,7 +783,7 @@ test('Content length too big (buffer)', async t => {
       path: '/'
     }, options)
   } catch (err: any) {
-    t.ok(err instanceof RequestAbortedError)
+    t.ok(err instanceof RequestAbortedError, `Not a RequestAbortedError: ${err}`)
     t.equal(err.message, `The content length (${buffer.constants.MAX_LENGTH + 10}) is bigger than the maximum allowed buffer (${buffer.constants.MAX_LENGTH})`)
   }
 })
@@ -837,7 +833,7 @@ test('Content length too big (string)', async t => {
       path: '/'
     }, options)
   } catch (err: any) {
-    t.ok(err instanceof RequestAbortedError)
+    t.ok(err instanceof RequestAbortedError, `Not a RequestAbortedError: ${err}`)
     t.equal(err.message, `The content length (${buffer.constants.MAX_STRING_LENGTH + 10}) is bigger than the maximum allowed string (${buffer.constants.MAX_STRING_LENGTH})`)
   }
 })
@@ -887,7 +883,7 @@ test('Content length too big custom option (buffer)', async t => {
       path: '/'
     }, { ...options, maxCompressedResponseSize: 1000 })
   } catch (err: any) {
-    t.ok(err instanceof RequestAbortedError)
+    t.ok(err instanceof RequestAbortedError, `Not a RequestAbortedError: ${err}`)
     t.equal(err.message, 'The content length (1100) is bigger than the maximum allowed buffer (1000)')
   }
 })
@@ -937,7 +933,7 @@ test('Content length too big custom option (string)', async t => {
       path: '/'
     }, { ...options, maxResponseSize: 1000 })
   } catch (err: any) {
-    t.ok(err instanceof RequestAbortedError)
+    t.ok(err instanceof RequestAbortedError, `Not a RequestAbortedError: ${err}`)
     t.equal(err.message, 'The content length (1100) is bigger than the maximum allowed string (1000)')
   }
 })
@@ -1025,7 +1021,7 @@ test('Body too big custom option (string)', async t => {
     }, { ...options, maxResponseSize: 1 })
     t.fail('Shold throw')
   } catch (err: any) {
-    t.ok(err instanceof RequestAbortedError)
+    t.ok(err instanceof RequestAbortedError, `Not a RequestAbortedError: ${err}`)
     t.equal(err.message, 'The content length (9) is bigger than the maximum allowed string (1)')
   }
 
@@ -1056,7 +1052,7 @@ test('Body too big custom option (buffer)', async t => {
     }, { ...options, maxCompressedResponseSize: 1 })
     t.fail('Shold throw')
   } catch (err: any) {
-    t.ok(err instanceof RequestAbortedError)
+    t.ok(err instanceof RequestAbortedError, `Not a RequestAbortedError ${err}`)
     t.equal(err.message, 'The content length (29) is bigger than the maximum allowed buffer (1)')
   }
 
@@ -1076,7 +1072,7 @@ test('Connection error', async t => {
       method: 'GET'
     }, options)
   } catch (err: any) {
-    t.ok(err instanceof ConnectionError)
+    t.ok(err instanceof ConnectionError, `Not a ConnectionError: ${err}`)
   }
 })
 
@@ -1091,7 +1087,7 @@ test('Throw if detects undici agent options', async t => {
       }
     })
   } catch (err: any) {
-    t.ok(err instanceof ConfigurationError)
+    t.ok(err instanceof ConfigurationError, `Not a ConfigurationError: ${err}`)
   }
 })
 
@@ -1156,7 +1152,7 @@ test('Check server fingerprint (failure)', async t => {
     }, options)
     t.fail('Should throw')
   } catch (err: any) {
-    t.ok(err instanceof ConnectionError)
+    t.ok(err instanceof ConnectionError, `Not a ConnectionError: ${err}`)
     t.equal(err.message, 'Server certificate CA fingerprint does not match the value configured in caFingerprint')
   }
   server.stop()
@@ -1180,7 +1176,7 @@ test('Should show local/remote socket addres in case of ECONNRESET', async t => 
     }, options)
     t.fail('should throw')
   } catch (err: any) {
-    t.ok(err instanceof ConnectionError)
+    t.ok(err instanceof ConnectionError, `Not a ConnectionError: ${err}`)
     if (err.message.includes('::1')) {
       t.match(err.message, /socket\shang\sup\s-\sLocal:\s::1:\d+,\sRemote:\s::1:\d+/)
     } else {

--- a/test/unit/transport.test.ts
+++ b/test/unit/transport.test.ts
@@ -523,7 +523,7 @@ test('ResponseError (query failure)', async t => {
 test('Retry mechanism', async t => {
   let count = 0
   const Conn = buildMockConnection({
-    onRequest(opts: ConnectionRequestParams): { body: any, statusCode: number } {
+    onRequest(_opts: ConnectionRequestParams): { body: any, statusCode: number } {
       count += 1
       return {
         body: { hello: 'world' },
@@ -553,7 +553,7 @@ test('Retry mechanism', async t => {
 test('Should not retry if the body is a stream', async t => {
   let count = 0
   const Conn = buildMockConnection({
-    onRequest(opts: ConnectionRequestParams): { body: any, statusCode: number } {
+    onRequest(_opts: ConnectionRequestParams): { body: any, statusCode: number } {
       count += 1
       return {
         body: { hello: 'world' },
@@ -588,7 +588,7 @@ test('Should not retry if the body is a stream', async t => {
 test('Should not retry if the bulkBody is a stream', async t => {
   let count = 0
   const Conn = buildMockConnection({
-    onRequest(opts: ConnectionRequestParams): { body: any, statusCode: number } {
+    onRequest(_opts: ConnectionRequestParams): { body: any, statusCode: number } {
       count += 1
       return {
         body: { hello: 'world' },
@@ -724,7 +724,7 @@ test('Retry on timeout error', async t => {
 
 test('Abort a request', async t => {
   const Conn = buildMockConnection({
-    onRequest(opts: ConnectionRequestParams): { body: any, statusCode: number } {
+    onRequest(_opts: ConnectionRequestParams): { body: any, statusCode: number } {
       return {
         body: { hello: 'world' },
         statusCode: 200

--- a/test/unit/undici-connection.test.ts
+++ b/test/unit/undici-connection.test.ts
@@ -125,7 +125,7 @@ test('Basic (https with tls agent)', async t => {
 test('Timeout support / 1', async t => {
   t.plan(1)
 
-  function handler (req: http.IncomingMessage, res: http.ServerResponse) {
+  function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
     setTimeout(() => res.end('ok'), 100)
   }
 
@@ -149,7 +149,7 @@ test('Timeout support / 1', async t => {
 test('Timeout support / 2', async t => {
   t.plan(2)
 
-  function handler (req: http.IncomingMessage, res: http.ServerResponse) {
+  function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
     res.writeHead(200, { 'content-type': 'text/plain' })
     setTimeout(() => res.end('ok'), 100)
   }
@@ -174,7 +174,7 @@ test('Timeout support / 2', async t => {
 test('Timeout support / 3', async t => {
   t.plan(2)
 
-  function handler (req: http.IncomingMessage, res: http.ServerResponse) {
+  function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
     setTimeout(() => res.end('ok'), 100)
   }
 
@@ -201,7 +201,7 @@ test('Timeout support / 3', async t => {
 test('Timeout support / 4', async t => {
   t.plan(2)
 
-  function handler (req: http.IncomingMessage, res: http.ServerResponse) {
+  function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
     setTimeout(() => res.end('ok'), 100)
   }
 
@@ -231,7 +231,7 @@ test('Timeout support / 4', async t => {
 test('Timeout support / 5', async t => {
   t.plan(1)
 
-  function handler (req: http.IncomingMessage, res: http.ServerResponse) {
+  function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
     res.end('ok')
   }
 
@@ -356,7 +356,7 @@ test('Send body as stream', async t => {
 test('Should not close a connection if there are open requests', async t => {
   t.plan(1)
 
-  function handler (req: http.IncomingMessage, res: http.ServerResponse) {
+  function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
     setTimeout(() => res.end('ok'), 100)
   }
 
@@ -450,7 +450,7 @@ test('Should disallow two-byte characters in URL path', async t => {
 test('Abort a request syncronously', async t => {
   t.plan(2)
 
-  function handler (req: http.IncomingMessage, res: http.ServerResponse) {
+  function handler (_req: http.IncomingMessage, _res: http.ServerResponse) {
     t.fail('The server should not be contacted')
   }
 
@@ -480,7 +480,7 @@ test('Abort a request syncronously', async t => {
 test('Abort a request asyncronously', async t => {
   t.plan(1)
 
-  function handler (req: http.IncomingMessage, res: http.ServerResponse) {
+  function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
     // might be called or not
     res.end('ok')
   }
@@ -522,7 +522,7 @@ test('Abort with a slow body', async t => {
   })
 
   const slowBody = new Readable({
-    read (size: number) {
+    read (_size: number) {
       setTimeout(() => {
         this.push('{"size":1, "query":{"match_all":{}}}')
         this.push(null) // EOF
@@ -553,7 +553,7 @@ test('Abort with a slow body', async t => {
 test('Bad content length', async t => {
   t.plan(2)
 
-  function handler (req: http.IncomingMessage, res: http.ServerResponse) {
+  function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
     const body = JSON.stringify({ hello: 'world' })
     res.setHeader('Content-Type', 'application/json;utf=8')
     res.setHeader('Content-Length', body.length + '')
@@ -579,7 +579,7 @@ test('Bad content length', async t => {
 test('Socket destryed while reading the body', async t => {
   t.plan(2)
 
-  function handler (req: http.IncomingMessage, res: http.ServerResponse) {
+  function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
     const body = JSON.stringify({ hello: 'world' })
     res.setHeader('Content-Type', 'application/json;utf=8')
     res.setHeader('Content-Length', body.length + '')
@@ -764,7 +764,7 @@ test('Content length too big custom option (string)', async t => {
 test('Body too big custom option (string)', async t => {
   t.plan(2)
 
-  function handler (req: http.IncomingMessage, res: http.ServerResponse) {
+  function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
     res.writeHead(200, {
       'content-type': 'application/json;utf=8',
       'transfer-encoding': 'chunked'
@@ -796,7 +796,7 @@ test('Body too big custom option (string)', async t => {
 test('Body too big custom option (buffer)', async t => {
   t.plan(2)
 
-  function handler (req: http.IncomingMessage, res: http.ServerResponse) {
+  function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
     res.writeHead(200, {
       'content-type': 'application/json;utf=8',
       'content-encoding': 'gzip',
@@ -954,7 +954,7 @@ test('Support mapbox vector tile', async t => {
 
   const mvtContent = 'GoMCCgRtZXRhEikSFAAAAQACAQMBBAAFAgYDBwAIBAkAGAMiDwkAgEAagEAAAP8//z8ADxoOX3NoYXJkcy5mYWlsZWQaD19zaGFyZHMuc2tpcHBlZBoSX3NoYXJkcy5zdWNjZXNzZnVsGg1fc2hhcmRzLnRvdGFsGhlhZ2dyZWdhdGlvbnMuX2NvdW50LmNvdW50GhdhZ2dyZWdhdGlvbnMuX2NvdW50LnN1bRoTaGl0cy50b3RhbC5yZWxhdGlvbhoQaGl0cy50b3RhbC52YWx1ZRoJdGltZWRfb3V0GgR0b29rIgIwACICMAIiCRkAAAAAAAAAACIECgJlcSICOAAogCB4Ag=='
 
-  function handler (req: http.IncomingMessage, res: http.ServerResponse) {
+  function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
     res.setHeader('Content-Type', 'application/vnd.mapbox-vector-tile')
     res.end(Buffer.from(mvtContent, 'base64'))
   }
@@ -974,7 +974,7 @@ test('Support mapbox vector tile', async t => {
 test('Check server fingerprint (success)', async t => {
   t.plan(1)
 
-  function handler (req: http.IncomingMessage, res: http.ServerResponse) {
+  function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
     res.end('ok')
   }
 
@@ -994,7 +994,7 @@ test('Check server fingerprint (success)', async t => {
 test('Check server fingerprint (failure)', async t => {
   t.plan(2)
 
-  function handler (req: http.IncomingMessage, res: http.ServerResponse) {
+  function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
     res.end('ok')
   }
 
@@ -1019,7 +1019,7 @@ test('Check server fingerprint (failure)', async t => {
 test('Should show local/remote socket addres in case of ECONNRESET', async t => {
   t.plan(2)
 
-  function handler (req: http.IncomingMessage, res: http.ServerResponse) {
+  function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
     res.destroy()
   }
 
@@ -1067,7 +1067,7 @@ test('Path without intial slash', async t => {
 test('as stream', async t => {
   t.plan(2)
 
-  function handler (req: http.IncomingMessage, res: http.ServerResponse) {
+  function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
     res.end('ok')
   }
 


### PR DESCRIPTION
Refactors `HttpConnection` to stop using the deprecated `'abort'` event on requests and the deprecated `'aborted'` event on responses.

Also does some basic linter cleanup, added/improved a few docstrings, and improved assertion messages for several unit tests.
