### PR TITLE
Handle warning headers as an array

### DIFF
--- a/src/Transport.ts
+++ b/src/Transport.ts
@@ -370,8 +370,12 @@ export default class Transport {
         if (this.headers?.warning == null) {
           return null
         }
-        return this.headers.warning
-          .split(/(?!\B"[^"]*),(?![^"]*"\B)/)
+
+        const { warning } = this.headers
+        // if multiple HTTP headers have the same name, Undici represents them as an array
+        const warnings: string[] = Array.isArray(warning) ? warning : [warning]
+        return warnings
+          .flatMap(w => w.split(/(?!\B"[^"]*),(?![^"]*"\B)/))
           .filter((warning) => warning.match(/^\d\d\d Elasticsearch-/))
       }
     }

--- a/test/unit/transport.test.ts
+++ b/test/unit/transport.test.ts
@@ -1144,6 +1144,39 @@ test('Warning header (multiple)', async t => {
   t.same(res.warnings, [warn3])
 })
 
+test('Warning header (multiple as array)', async t => {
+  const warn1 = '112 - "cache down" "Wed, 21 Oct 2015 07:28:00 GMT"'
+  const warn2 = '199 agent "Error message" "2015-01-01"'
+  const warn3 = '299 Elasticsearch-7.17.10-fecd68e3150eda0c307ab9a9d7557f5d5fd71349 "the default value for the ?wait_for_active_shards parameter will change"'
+
+  const Conn = buildMockConnection({
+    onRequest(opts: ConnectionRequestParams): { body: any, statusCode: number, headers: http.IncomingHttpHeaders } {
+      return {
+        body: { hello: 'world' },
+        statusCode: 200,
+        headers: {
+          // @ts-expect-error
+          warning: [warn1, warn2, warn3],
+        }
+      }
+    }
+  })
+
+  const pool = new WeightedConnectionPool({ Connection: Conn })
+  pool.addConnection('http://localhost:9200')
+
+  const transport = new Transport({
+    connectionPool: pool,
+    compression: true
+  })
+
+  const res = await transport.request({
+    method: 'GET',
+    path: '/hello'
+  }, { meta: true })
+  t.same(res.warnings, [warn3])
+})
+
 test('No warnings', async t => {
   const pool = new WeightedConnectionPool({ Connection: MockConnection })
   pool.addConnection('http://localhost:9200')


### PR DESCRIPTION
Fixes https://github.com/elastic/elastic-transport-js/issues/95
