### PR TITLE
Use node: prefix for stdlib imports

### DIFF
--- a/src/Diagnostic.ts
+++ b/src/Diagnostic.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { EventEmitter } from 'events'
+import { EventEmitter } from 'node:events'
 import { ElasticsearchClientError, ConfigurationError } from './errors'
 import { ConnectionRequestOptions } from './connection'
 import { ResurrectEvent } from './pool'

--- a/src/Serializer.ts
+++ b/src/Serializer.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { stringify } from 'querystring'
+import { stringify } from 'node:querystring'
 import Debug from 'debug'
 import sjson from 'secure-json-parse'
 import { SerializationError, DeserializationError } from './errors'

--- a/src/Transport.ts
+++ b/src/Transport.ts
@@ -18,11 +18,12 @@
  */
 
 import Debug from 'debug'
-import os from 'os'
-import * as http from 'http'
-import zlib from 'zlib'
-import buffer from 'buffer'
-import { promisify } from 'util'
+import os from 'node:os'
+import * as http from 'node:http'
+import zlib from 'node:zlib'
+import buffer from 'node:buffer'
+import { promisify } from 'node:util'
+import process from 'node:process'
 import ms from 'ms'
 import {
   ConnectionError,
@@ -37,7 +38,7 @@ import {
 import { Connection, ConnectionRequestParams } from './connection'
 import Diagnostic from './Diagnostic'
 import Serializer from './Serializer'
-import { Readable as ReadableStream } from 'stream'
+import { Readable as ReadableStream } from 'node:stream'
 import { BaseConnectionPool } from './pool'
 import {
   nodeFilterFn,

--- a/src/connection/BaseConnection.ts
+++ b/src/connection/BaseConnection.ts
@@ -17,11 +17,11 @@
  * under the License.
  */
 
-import { inspect } from 'util'
-import * as http from 'http'
-import { URL } from 'url'
-import { ConnectionOptions as TlsConnectionOptions, TLSSocket, DetailedPeerCertificate } from 'tls'
-import { Readable as ReadableStream } from 'stream'
+import { inspect } from 'node:util'
+import * as http from 'node:http'
+import { URL } from 'node:url'
+import { ConnectionOptions as TlsConnectionOptions, TLSSocket, DetailedPeerCertificate } from 'node:tls'
+import { Readable as ReadableStream } from 'node:stream'
 import Diagnostic from '../Diagnostic'
 import {
   ApiKeyAuth,

--- a/src/connection/HttpConnection.ts
+++ b/src/connection/HttpConnection.ts
@@ -20,11 +20,11 @@
 /* eslint-disable @typescript-eslint/restrict-template-expressions */
 
 import hpagent from 'hpagent'
-import http from 'http'
-import https from 'https'
+import http from 'node:http'
+import https from 'node:https'
 import Debug from 'debug'
-import buffer from 'buffer'
-import { TLSSocket } from 'tls'
+import buffer from 'node:buffer'
+import { TLSSocket } from 'node:tls'
 import BaseConnection, {
   ConnectionOptions,
   ConnectionRequestParams,
@@ -35,14 +35,14 @@ import BaseConnection, {
   getIssuerCertificate
 } from './BaseConnection'
 import { kCaFingerprint } from '../symbols'
-import { Readable as ReadableStream, pipeline } from 'stream'
+import { Readable as ReadableStream, pipeline } from 'node:stream'
 import {
   ConfigurationError,
   ConnectionError,
   RequestAbortedError,
   TimeoutError
 } from '../errors'
-import { setTimeout as setTimeoutPromise } from 'timers/promises'
+import { setTimeout as setTimeoutPromise } from 'node:timers/promises'
 import { HttpAgentOptions } from '../types'
 
 const debug = Debug('elasticsearch')

--- a/src/connection/UndiciConnection.ts
+++ b/src/connection/UndiciConnection.ts
@@ -20,9 +20,9 @@
 /* eslint-disable @typescript-eslint/restrict-template-expressions */
 
 import Debug from 'debug'
-import buffer from 'buffer'
-import { TLSSocket } from 'tls'
-import { Socket } from 'net'
+import buffer from 'node:buffer'
+import { TLSSocket } from 'node:tls'
+import { Socket } from 'node:net'
 import BaseConnection, {
   ConnectionOptions,
   ConnectionRequestParams,

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import * as http from 'http'
+import * as http from 'node:http'
 import { DiagnosticResult } from './types'
 import { RedactionOptions } from './Transport'
 import { redactDiagnostic } from './security'

--- a/src/pool/BaseConnectionPool.ts
+++ b/src/pool/BaseConnectionPool.ts
@@ -17,8 +17,8 @@
  * under the License.
  */
 
-import { URL } from 'url'
-import { ConnectionOptions as TlsConnectionOptions } from 'tls'
+import { URL } from 'node:url'
+import { ConnectionOptions as TlsConnectionOptions } from 'node:tls'
 import Debug from 'debug'
 import Diagnostic from '../Diagnostic'
 import { kCaFingerprint } from '../symbols'

--- a/src/pool/ClusterConnectionPool.ts
+++ b/src/pool/ClusterConnectionPool.ts
@@ -21,7 +21,7 @@ import BaseConnectionPool, {
   ConnectionPoolOptions,
   GetConnectionOptions
 } from './BaseConnectionPool'
-import assert from 'assert'
+import assert from 'node:assert'
 import Debug from 'debug'
 import { Connection, BaseConnection, ConnectionOptions } from '../connection'
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,9 +17,9 @@
  * under the License.
  */
 
-import { Readable as ReadableStream } from 'stream'
-import { URL } from 'url'
-import * as http from 'http'
+import { Readable as ReadableStream } from 'node:stream'
+import { URL } from 'node:url'
+import * as http from 'node:http'
 import { Connection, ConnectionOptions, ConnectionRequestParams } from './connection'
 import { TransportRequestParams, TransportRequestOptions } from './Transport'
 


### PR DESCRIPTION
Using the `node:` [import specifier](https://nodejs.org/api/esm.html#import-specifiers) brings us a step closer to supporting other JS runtinmes.
