### PR TITLE
fix: Add `noop` to request errors during cleanup

### DIFF
--- a/src/connection/HttpConnection.ts
+++ b/src/connection/HttpConnection.ts
@@ -134,7 +134,6 @@ export default class HttpConnection extends BaseConnection {
 
       const onResponse = (response: http.IncomingMessage): void => {
         cleanListeners()
-        request.on('error', noop) // There are some edge cases where the request emits an error while processing the response.
         this._openRequests--
 
         if (options.asStream === true) {
@@ -254,7 +253,7 @@ export default class HttpConnection extends BaseConnection {
             /* istanbul ignore next */
             if (issuerCertificate == null) {
               onError(new Error('Invalid or malformed certificate'))
-              request.once('error', () => {}) // we need to catch the request aborted error
+              request.once('error', noop) // we need to catch the request aborted error
               return request.destroy()
             }
 
@@ -262,7 +261,7 @@ export default class HttpConnection extends BaseConnection {
             /* istanbul ignore else */
             if (!isCaFingerprintMatch(this[kCaFingerprint], issuerCertificate.fingerprint256)) {
               onError(new Error('Server certificate CA fingerprint does not match the value configured in caFingerprint'))
-              request.once('error', () => {}) // we need to catch the request aborted error
+              request.once('error', noop) // we need to catch the request aborted error
               return request.destroy()
             }
           })
@@ -299,6 +298,7 @@ export default class HttpConnection extends BaseConnection {
         request.removeListener('response', onResponse)
         request.removeListener('timeout', onTimeout)
         request.removeListener('error', onError)
+        request.on('error', noop)
         request.removeListener('socket', onSocket)
         if (options.signal != null) {
           if ('removeEventListener' in options.signal) {


### PR DESCRIPTION
<!--

Hello there!

Thank you for opening a pull request!
Please remember to always tag the relative issue (if any) and give a brief explanation on what your changes are doing.

If you are patching a security issue, please take a look at https://www.elastic.co/community/security

Finally, please make sure you have signed the Contributor License Agreement
We are not asking you to assign copyright to us, but to give us the right to distribute your code without restriction.
We ask this of all contributors in order to assure our users of the origin and continuing existence of the code. You only need to sign the CLA once.
https://www.elastic.co/contributor-agreement/

Happy coding!

-->

We noticed a potential race condition that's hard to reproduce (it only happened 29 times in the last 30 days in our production environment). Kibana crashes with `EPIPE` during write operations (task manager writing the result of a task, task manager claiming tasks, Kibana during the setup phase, and multiple POST requests).
![image](https://github.com/user-attachments/assets/19598ea0-9608-4acf-8227-655829e4022c)

The lack of stack traces in Kibana (https://github.com/elastic/elasticsearch-js/issues/2235) doesn't help to identify if it's related to one specific request or spread across multiple ones. But the gut feeling is a race condition where potentially, multiple errors are emitted at once and only one is caught, cleaning the listener, and the next one crashes the app.

Happy to close this PR if you think that this change is not safe/sensible.