### PR TITLE
ci: Adjust timeout on Undici tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@tapjs/clock": "3.0.0",
     "@types/debug": "4.1.12",
     "@types/ms": "0.7.34",
-    "@types/node": "20.16.11",
+    "@types/node": "18.19.55",
     "@types/sinonjs__fake-timers": "8.1.5",
     "@types/stoppable": "1.1.3",
     "@types/tap": "15.0.12",


### PR DESCRIPTION
Undici timer refactor in https://github.com/nodejs/undici/pull/3495 included a performance improvement that handles timeouts under 500ms differently, so tests expecting a `TimeoutError` when the timeout was smaller than 500ms started to fail.

Fixes https://github.com/elastic/elastic-transport-js/issues/155.