### PR TITLE
Install fake-timers from npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   },
   "devDependencies": {
     "@opentelemetry/sdk-trace-base": "1.26.0",
-    "@sinonjs/fake-timers": "github:sinonjs/fake-timers#77a516c",
+    "@sinonjs/fake-timers": "13.0.4",
     "@tapjs/clock": "3.0.0",
     "@types/debug": "4.1.12",
     "@types/ms": "0.7.34",


### PR DESCRIPTION
For historical reasons we were using `@sinonjs/fake-timers` installed from a specific commit hash on Github. This is no longer necessary.
