### PR TITLE
Update Renovate settings

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,23 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>elastic/renovate-config"
+  ],
+  "schedule": [
+    "* * * * 0"
+  ],
+  "packageRules": [
+    {
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "automerge": true
+    },
+    {
+      "matchDepTypes": [
+        "dependencies"
+      ],
+      "rangeStrategy": "bump",
+      "automerge": false
+    }
   ]
 }


### PR DESCRIPTION
Experimenting with Renovate settings. I want less interaction when `devDependencies` are bumped, and I want to see if `dependencies` management is sustainable:

- only allow PRs to be opened on Sundays; avoids getting patch PRs every other day
- allow `devDependencies` bumps to auto-merge if tests pass
- bump `dependencies` within their allowed range but do not auto-merge
