### PR TITLE
fix: Drop unused warnings property from request options

### DIFF
--- a/src/Transport.ts
+++ b/src/Transport.ts
@@ -147,7 +147,6 @@ export interface TransportRequestOptions {
   compression?: boolean
   id?: any
   context?: Context
-  warnings?: string[]
   opaqueId?: string
   signal?: AbortSignal
   maxResponseSize?: number


### PR DESCRIPTION
Pretty certain this was a typo that has been here for ages!
