### PR TITLE
Don't let Renovate upgrade @opentelemetry/api

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,7 +18,10 @@
         "dependencies"
       ],
       "rangeStrategy": "bump",
-      "automerge": false
+      "automerge": false,
+      "matchPackageNames": [
+        "!@opentelemetry/api"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Intentionally keeping `@opentelemetry/api` dependency broad so it is easy to support for projects that already depend on the package.
