### PR TITLE
Remove default 30-second timeout on HTTP requests

### DIFF
--- a/src/Transport.ts
+++ b/src/Transport.ts
@@ -81,7 +81,7 @@ import {
   kRetryBackoff,
   kOtelTracer
 } from './symbols'
-import { setTimeout as setTimeoutPromise } from 'node:timers/promises'
+import { setTimeout } from 'node:timers/promises'
 import opentelemetry, { Attributes, Exception, SpanKind, SpanStatusCode, Span, Tracer } from '@opentelemetry/api'
 
 const { version: clientVersion } = require('../package.json') // eslint-disable-line
@@ -657,7 +657,7 @@ export default class Transport {
                 const backoff = options.retryBackoff ?? this[kRetryBackoff]
                 const backoffWait = backoff(0, 4, meta.attempts)
                 if (backoffWait > 0) {
-                  await setTimeoutPromise(backoffWait * 1000)
+                  await setTimeout(backoffWait * 1000)
                 }
               }
 

--- a/src/connection/BaseConnection.ts
+++ b/src/connection/BaseConnection.ts
@@ -42,7 +42,7 @@ export interface ConnectionOptions {
   status?: string
   auth?: BasicAuth | ApiKeyAuth | BearerAuth
   diagnostic?: Diagnostic
-  timeout?: number
+  timeout?: number | null
   agent?: HttpAgentOptions | UndiciAgentOptions | agentFn | boolean
   proxy?: string | URL
   caFingerprint?: string
@@ -64,7 +64,7 @@ export interface ConnectionRequestOptions {
   maxResponseSize?: number
   maxCompressedResponseSize?: number
   signal?: AbortSignal
-  timeout?: number
+  timeout?: number | null
 }
 
 export interface ConnectionRequestOptionsAsStream extends ConnectionRequestOptions {
@@ -90,7 +90,7 @@ export default class BaseConnection {
   url: URL
   tls: TlsConnectionOptions | null
   id: string
-  timeout: number
+  timeout: number | null
   headers: http.IncomingHttpHeaders
   deadCount: number
   resurrectTimeout: number
@@ -111,6 +111,7 @@ export default class BaseConnection {
     this.tls = opts.tls ?? null
     this.id = opts.id ?? stripAuth(opts.url.href)
     this.headers = prepareHeaders(opts.headers, opts.auth)
+    this.timeout = opts.timeout ?? null
     this.timeout = opts.timeout ?? 30000
     this.deadCount = 0
     this.resurrectTimeout = 0

--- a/src/connection/HttpConnection.ts
+++ b/src/connection/HttpConnection.ts
@@ -338,7 +338,9 @@ export default class HttpConnection extends BaseConnection {
       port: url.port !== '' ? url.port : undefined,
       headers: this.headers,
       agent: this.agent,
-      timeout: options.timeout ?? this.timeout
+      // only set a timeout if it has a value; default to no timeout
+      // see https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-network.html#_http_client_configuration
+      timeout: options.timeout ?? this.timeout ?? undefined
     }
 
     const paramsKeys = Object.keys(params)

--- a/src/connection/HttpConnection.ts
+++ b/src/connection/HttpConnection.ts
@@ -44,7 +44,7 @@ import {
   RequestAbortedError,
   TimeoutError
 } from '../errors'
-import { setTimeout as setTimeoutPromise } from 'node:timers/promises'
+import { setTimeout } from 'node:timers/promises'
 import { HttpAgentOptions } from '../types'
 
 const debug = Debug('elasticsearch')
@@ -316,7 +316,7 @@ export default class HttpConnection extends BaseConnection {
   async close (): Promise<void> {
     debug('Closing connection', this.id)
     while (this._openRequests > 0) {
-      await setTimeoutPromise(1000)
+      await setTimeout(1000)
     }
     /* istanbul ignore else */
     if (this.agent !== undefined) {
@@ -328,7 +328,7 @@ export default class HttpConnection extends BaseConnection {
     const url = this.url
     let search = url.search
     let pathname = url.pathname
-    const request = {
+    const request: http.ClientRequestArgs = {
       protocol: url.protocol,
       hostname: url.hostname[0] === '['
         ? url.hostname.slice(1, -1)

--- a/src/connection/UndiciConnection.ts
+++ b/src/connection/UndiciConnection.ts
@@ -77,8 +77,10 @@ export default class Connection extends BaseConnection {
       pipelining: 1,
       maxHeaderSize: 16384,
       connections: 256,
-      headersTimeout: this.timeout,
-      bodyTimeout: this.timeout,
+      // only set a timeout if it has a value; default to no timeout
+      // see https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-network.html#_http_client_configuration
+      headersTimeout: this.timeout ?? undefined,
+      bodyTimeout: this.timeout ?? undefined,
       ...opts.agent
     }
 

--- a/test/unit/http-connection.test.ts
+++ b/test/unit/http-connection.test.ts
@@ -17,19 +17,20 @@
  * under the License.
  */
 
+import { setTimeout } from 'node:timers/promises'
+import { URL } from 'node:url'
+import * as http from 'node:http'
+import { Agent } from 'node:http'
+import buffer from 'node:buffer'
+import { gzipSync, deflateSync } from 'node:zlib'
+import { Readable } from 'node:stream'
+import net from "node:net";
 import { test } from 'tap'
-import { URL } from 'url'
-import * as http from 'http'
-import { Agent } from 'http'
-import buffer from 'buffer'
-import { gzipSync, deflateSync } from 'zlib'
-import { Readable } from 'stream'
 import hpagent from 'hpagent'
 import intoStream from 'into-stream'
 import { AbortController as LegacyAbortController } from 'node-abort-controller'
 import { buildServer } from '../utils'
 import { HttpConnection, errors, ConnectionOptions } from '../../'
-import net from "net";
 
 const {
   TimeoutError,
@@ -128,43 +129,84 @@ test('Basic (https with tls agent)', async t => {
   server.stop()
 })
 
-test('Custom http agent', async t => {
-  t.plan(5)
+test('Agent support', t => {
+  t.test('Custom http agent', async t => {
+    t.plan(5)
 
-  function handler (req: http.IncomingMessage, res: http.ServerResponse) {
-    t.match(req.headers, {
-      'x-custom-test': /true/,
-      connection: /keep-alive/
+    function handler (req: http.IncomingMessage, res: http.ServerResponse) {
+      t.match(req.headers, {
+        'x-custom-test': /true/,
+        connection: /keep-alive/
+      })
+      res.end('ok')
+    }
+
+    const [{ port }, server] = await buildServer(handler)
+    const agent = new Agent({
+      keepAlive: true,
+      keepAliveMsecs: 1000,
+      maxSockets: 42,
+      maxFreeSockets: 256
     })
-    res.end('ok')
-  }
+    const connection = new HttpConnection({
+      url: new URL(`http://localhost:${port}`),
+      agent: opts => {
+        t.equal(opts.url.toString(), new URL(`http://localhost:${port}`).toString())
+        return agent
+      }
+    })
+    t.equal(connection.agent?.maxSockets, 42)
 
-  const [{ port }, server] = await buildServer(handler)
-  const agent = new Agent({
-    keepAlive: true,
-    keepAliveMsecs: 1000,
-    maxSockets: 42,
-    maxFreeSockets: 256
+    const res = await connection.request({
+      path: '/hello',
+      method: 'GET',
+      headers: {
+        'X-Custom-Test': 'true'
+      }
+    }, options)
+    t.match(res.headers, { connection: /keep-alive/ })
+    t.equal(res.body, 'ok')
+    server.stop()
   })
-  const connection = new HttpConnection({
-    url: new URL(`http://localhost:${port}`),
-    agent: opts => {
-      t.equal(opts.url.toString(), new URL(`http://localhost:${port}`).toString())
-      return agent
+
+  t.test('Proxy agent (http)', t => {
+    t.plan(1)
+
+    const connection = new HttpConnection({
+      url: new URL('http://localhost:9200'),
+      proxy: 'http://localhost:8080'
+    })
+
+    t.ok(connection.agent instanceof hpagent.HttpProxyAgent)
+  })
+
+  t.test('Proxy agent (https)', t => {
+    t.plan(1)
+
+    const connection = new HttpConnection({
+      url: new URL('https://localhost:9200'),
+      proxy: 'http://localhost:8080'
+    })
+
+    t.ok(connection.agent instanceof hpagent.HttpsProxyAgent)
+  })
+
+  t.test('Throw if detects undici agent options', async t => {
+    t.plan(1)
+
+    try {
+      new HttpConnection({
+        url: new URL('http://localhost:9200'),
+        agent: {
+          connections: 42
+        }
+      })
+    } catch (err: any) {
+      t.ok(err instanceof ConfigurationError, `Not a ConfigurationError: ${err}`)
     }
   })
-  t.equal(connection.agent?.maxSockets, 42)
 
-  const res = await connection.request({
-    path: '/hello',
-    method: 'GET',
-    headers: {
-      'X-Custom-Test': 'true'
-    }
-  }, options)
-  t.match(res.headers, { connection: /keep-alive/ })
-  t.equal(res.body, 'ok')
-  server.stop()
+  t.end()
 })
 
 test('Disable keep alive', async t => {
@@ -200,81 +242,128 @@ test('Disable keep alive', async t => {
   server.stop()
 })
 
-test('Timeout support / 1', async t => {
-  t.plan(1)
+test('Timeout support', t => {
+  t.test('Timeout support / 1', async t => {
+    t.plan(1)
+    t.clock.enter()
+    t.teardown(() => t.clock.exit())
 
-  function handler (req: http.IncomingMessage, res: http.ServerResponse) {
-    setTimeout(() => res.end('ok'), 100)
-  }
+    async function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
+      await setTimeout(100)
+      res.end('ok')
+    }
 
-  const [{ port }, server] = await buildServer(handler)
-  const connection = new HttpConnection({
-    url: new URL(`http://localhost:${port}`),
-    timeout: 50
-  })
-
-  try {
-    await connection.request({
-      path: '/hello',
-      method: 'GET'
-    }, options)
-  } catch (err: any) {
-    t.ok(err instanceof TimeoutError, `Not a TimeoutError: ${err}`)
-  }
-  server.stop()
-})
-
-test('Timeout support / 2', async t => {
-  t.plan(1)
-
-  function handler (req: http.IncomingMessage, res: http.ServerResponse) {
-    setTimeout(() => res.end('ok'), 100)
-  }
-
-  const [{ port }, server] = await buildServer(handler)
-  const connection = new HttpConnection({
-    url: new URL(`http://localhost:${port}`)
-  })
-
-  try {
-    await connection.request({
-      path: '/hello',
-      method: 'GET'
-    }, {
-      timeout: 50,
-      ...options
+    const [{ port }, server] = await buildServer(handler)
+    const connection = new HttpConnection({
+      url: new URL(`http://localhost:${port}`),
+      timeout: 50
     })
-  } catch (err: any) {
-    t.ok(err instanceof TimeoutError, `Not a TimeoutError: ${err}`)
-  }
-  server.stop()
-})
 
-test('Timeout support / 3', async t => {
-  t.plan(1)
-
-  function handler (req: http.IncomingMessage, res: http.ServerResponse) {
-    setTimeout(() => res.end('ok'), 100)
-  }
-
-  const [{ port }, server] = await buildServer(handler)
-  const connection = new HttpConnection({
-    url: new URL(`http://localhost:${port}`),
-    timeout: 1000
+    try {
+      const res = connection.request({
+        path: '/hello',
+        method: 'GET'
+      }, options)
+      t.clock.advance(50)
+      await res
+    } catch (err: any) {
+      t.ok(err instanceof TimeoutError, `Not a TimeoutError: ${err}`)
+    }
+    server.stop()
   })
 
-  try {
-    await connection.request({
-      path: '/hello',
-      method: 'GET'
-    }, {
-      timeout: 50,
-      ...options
+  t.test('Timeout support / 2', async t => {
+    t.plan(1)
+    t.clock.enter()
+    t.teardown(() => t.clock.exit())
+
+    async function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
+      await setTimeout(100)
+      res.end('ok')
+    }
+
+    const [{ port }, server] = await buildServer(handler)
+    const connection = new HttpConnection({
+      url: new URL(`http://localhost:${port}`)
     })
-  } catch (err: any) {
-    t.ok(err instanceof TimeoutError, `Not a TimeoutError: ${err}`)
-  }
-  server.stop()
+
+    try {
+      const res = connection.request({
+        path: '/hello',
+        method: 'GET'
+      }, {
+          timeout: 50,
+          ...options
+        })
+      t.clock.advance(50)
+      await res
+    } catch (err: any) {
+      t.ok(err instanceof TimeoutError, `Not a TimeoutError: ${err}`)
+    }
+    server.stop()
+  })
+
+  t.test('Timeout support / 3', async t => {
+    t.plan(1)
+    t.clock.enter()
+    t.teardown(() => t.clock.exit())
+
+    async function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
+      await setTimeout(100)
+      res.end('ok')
+    }
+
+    const [{ port }, server] = await buildServer(handler)
+    const connection = new HttpConnection({
+      url: new URL(`http://localhost:${port}`),
+      timeout: 1000
+    })
+
+    try {
+      const res = connection.request({
+        path: '/hello',
+        method: 'GET'
+      }, {
+          timeout: 50,
+          ...options
+        })
+      t.clock.advance(50)
+      await res
+    } catch (err: any) {
+      t.ok(err instanceof TimeoutError, `Not a TimeoutError: ${err}`)
+    }
+    server.stop()
+  })
+
+  t.test ('No default timeout', { skip: true }, async t => {
+    t.plan(1)
+    t.clock.enter()
+    t.teardown(() => t.clock.exit())
+
+    async function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
+      await setTimeout(31000)
+      res.end('ok')
+    }
+
+    const [{ port }, server] = await buildServer(handler)
+    const connection = new HttpConnection({
+      url: new URL(`http://localhost:${port}`)
+    })
+    try {
+      const res = connection.request({
+        path: '/hello',
+        method: 'GET'
+      }, options)
+      t.clock.advance(31000)
+      await res
+      t.ok('Request did not time out')
+    } catch {
+      t.fail('No error should be thrown')
+    }
+    server.stop()
+  })
+
+  t.end()
 })
 
 test('Should concatenate the querystring', async t => {
@@ -383,8 +472,9 @@ test('Send body as stream', async t => {
 test('Should not close a connection if there are open requests', async t => {
   t.plan(1)
 
-  function handler (req: http.IncomingMessage, res: http.ServerResponse) {
-    setTimeout(() => res.end('ok'), 100)
+  async function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
+    await setTimeout(100)
+    res.end('ok')
   }
 
   const [{ port }, server] = await buildServer(handler)
@@ -535,62 +625,129 @@ test('Port handling', t => {
   t.end()
 })
 
-test('Abort a request syncronously', async t => {
-  t.plan(1)
+test('Abort request', t => {
+  t.test('Abort a request syncronously', async t => {
+    t.plan(1)
 
-  function handler (_req: http.IncomingMessage, _res: http.ServerResponse) {
-    t.fail('The server should not be contacted')
-  }
+    function handler (_req: http.IncomingMessage, _res: http.ServerResponse) {
+      t.fail('The server should not be contacted')
+    }
 
-  const [{ port }, server] = await buildServer(handler)
-  const connection = new HttpConnection({
-    url: new URL(`http://localhost:${port}`),
-    headers: { 'x-foo': 'bar' }
-  })
-
-  const controller = new AbortController()
-  connection.request(
-    { path: '/hello', method: 'GET' },
-    { signal: controller.signal, ...options })
-    .catch(err => {
-      t.ok(err instanceof RequestAbortedError, `Not a RequestAbortedError: ${err}`)
-      server.stop()
+    const [{ port }, server] = await buildServer(handler)
+    const connection = new HttpConnection({
+      url: new URL(`http://localhost:${port}`),
+      headers: { 'x-foo': 'bar' }
     })
 
-  controller.abort()
-  await connection.close()
-})
+    const controller = new AbortController()
+    connection.request(
+      { path: '/hello', method: 'GET' },
+      { signal: controller.signal, ...options })
+      .catch(err => {
+        t.ok(err instanceof RequestAbortedError, `Not a RequestAbortedError: ${err}`)
+        server.stop()
+      })
 
-test('Abort a request asyncronously', async t => {
-  t.plan(1)
-
-  function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
-    // might be called or not
-    res.end('ok')
-  }
-
-  const [{ port }, server] = await buildServer(handler)
-  const connection = new HttpConnection({
-    url: new URL(`http://localhost:${port}`),
-    headers: { 'x-foo': 'bar' }
+    controller.abort()
+    await connection.close()
   })
 
-  const controller = new AbortController()
-  setImmediate(() => controller.abort())
-  try {
+  t.test('Abort a request asyncronously', async t => {
+    t.plan(1)
+
+    function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
+      // might be called or not
+      res.end('ok')
+    }
+
+    const [{ port }, server] = await buildServer(handler)
+    const connection = new HttpConnection({
+      url: new URL(`http://localhost:${port}`),
+      headers: { 'x-foo': 'bar' }
+    })
+
+    const controller = new AbortController()
+    setImmediate(() => controller.abort())
+    try {
+      await connection.request({
+        path: '/hello',
+        method: 'GET'
+      }, {
+        signal: controller.signal,
+        ...options
+      })
+    } catch (err: any) {
+      t.ok(err instanceof RequestAbortedError, `Not a RequestAbortedError: ${err}`)
+    }
+
+    await connection.close()
+    server.stop()
+  })
+
+  t.test('Abort with a slow body', async t => {
+    t.plan(1)
+
+    const controller = new AbortController()
+    const connection = new HttpConnection({
+      url: new URL('https://localhost:9200'),
+    })
+
+    const slowBody = new Readable({
+      async read (_size: number) {
+        await setTimeout(1000, { ref: false })
+        this.push('{"size":1, "query":{"match_all":{}}}')
+        this.push(null) // EOF
+      }
+    })
+
+    setImmediate(() => controller.abort())
+    try {
+      await connection.request({
+        method: 'GET',
+        path: '/',
+        // @ts-ignore
+        body: slowBody
+      }, {
+        signal: controller.signal,
+        ...options
+      })
+    } catch (err: any) {
+      t.ok(err instanceof RequestAbortedError, `Not a RequestAbortedError: ${err}`)
+    }
+  })
+
+  t.test('Cleanup abort listener', async t => {
+    t.plan(2)
+
+    // uses legacy node-abort-controller polyfill package because the global
+    // AbortController's signal does not let expose an `eventEmitter` property for
+    // us to inspect, but the legacy package does!
+    const controller = new LegacyAbortController()
+
+    function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
+      // @ts-expect-error
+      t.equal(controller.signal.eventEmitter.listeners('abort').length, 1)
+      res.end('ok')
+    }
+
+    const [{ port }, server] = await buildServer(handler)
+    const connection = new HttpConnection({
+      url: new URL(`http://localhost:${port}`)
+    })
+
     await connection.request({
       path: '/hello',
-      method: 'GET'
+      method: 'GET',
     }, {
-      signal: controller.signal,
-      ...options
+      ...options,
+      signal: controller.signal as AbortSignal
     })
-  } catch (err: any) {
-    t.ok(err instanceof RequestAbortedError, `Not a RequestAbortedError: ${err}`)
-  }
+    // @ts-expect-error
+    t.equal(controller.signal.eventEmitter.listeners('abort').length, 0)
+    server.stop()
+  })
 
-  await connection.close()
-  server.stop()
+  t.end()
 })
 
 test('Should correctly resolve request path / 1', t => {
@@ -625,101 +782,249 @@ test('Should correctly resolve request path / 2', t => {
   )
 })
 
-test('Proxy agent (http)', t => {
-  t.plan(1)
+test('Content length', t => {
+  // The nodejs http agent will try to wait for the whole
+  // body to arrive before closing the request, so this
+  // test might take some time.
+  t.test('Bad content length', async t => {
+    t.plan(2)
 
-  const connection = new HttpConnection({
-    url: new URL('http://localhost:9200'),
-    proxy: 'http://localhost:8080'
+    function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
+      const body = JSON.stringify({ hello: 'world' })
+      res.setHeader('Content-Type', 'application/json;utf=8')
+      res.setHeader('Content-Length', body.length + '')
+      res.end(body.slice(0, -5))
+    }
+
+    const [{ port }, server] = await buildServer(handler)
+    const connection = new HttpConnection({
+      url: new URL(`http://localhost:${port}`)
+    })
+    try {
+      await connection.request({
+        path: '/hello',
+        method: 'GET'
+      }, options)
+    } catch (err: any) {
+      t.ok(err instanceof ConnectionError, `Not a ConnectionError: ${err}`)
+      t.equal(err.message, 'Response aborted while reading the body')
+    }
+    server.stop()
   })
 
-  t.ok(connection.agent instanceof hpagent.HttpProxyAgent)
-})
+  t.test('Content length too big (buffer)', async t => {
+    t.plan(3)
 
-test('Proxy agent (https)', t => {
-  t.plan(1)
+    class MyConnection extends HttpConnection {
+      constructor (opts: ConnectionOptions) {
+        super(opts)
+        // @ts-expect-error
+        this.makeRequest = () => {
+          const stream = intoStream(JSON.stringify({ hello: 'world' }))
+          // @ts-expect-error
+          stream.statusCode = 200
+          // @ts-expect-error
+          stream.headers = {
+            'content-type': 'application/json;utf=8',
+            'content-encoding': 'gzip',
+            'content-length': buffer.constants.MAX_LENGTH + 10,
+            connection: 'keep-alive',
+            date: new Date().toISOString()
+          }
+          stream.on('close', () => t.pass('Stream destroyed'))
+          return {
+            abort () {},
+            removeListener () {},
+            setNoDelay () {},
+            end () {},
+            on (event: string, cb: () => void) {
+              if (event === 'response') {
+                process.nextTick(cb, stream)
+              }
+            }
+          }
+        }
+      }
+    }
 
-  const connection = new HttpConnection({
-    url: new URL('https://localhost:9200'),
-    proxy: 'http://localhost:8080'
-  })
+    const connection = new MyConnection({
+      url: new URL('http://localhost:9200')
+    })
 
-  t.ok(connection.agent instanceof hpagent.HttpsProxyAgent)
-})
-
-test('Abort with a slow body', async t => {
-  t.plan(1)
-
-  const controller = new AbortController()
-  const connection = new HttpConnection({
-    url: new URL('https://localhost:9200'),
-  })
-
-  const slowBody = new Readable({
-    read (_size: number) {
-      setTimeout(() => {
-        this.push('{"size":1, "query":{"match_all":{}}}')
-        this.push(null) // EOF
-      }, 1000).unref()
+    try {
+      await connection.request({
+        method: 'GET',
+        path: '/'
+      }, options)
+    } catch (err: any) {
+      t.ok(err instanceof RequestAbortedError, `Not a RequestAbortedError: ${err}`)
+      t.equal(err.message, `The content length (${buffer.constants.MAX_LENGTH + 10}) is bigger than the maximum allowed buffer (${buffer.constants.MAX_LENGTH})`)
     }
   })
 
-  setImmediate(() => controller.abort())
-  try {
-    await connection.request({
-      method: 'GET',
-      path: '/',
-      // @ts-ignore
-      body: slowBody
-    }, {
-      signal: controller.signal,
-      ...options
+  t.test('Content length too big (string)', async t => {
+    t.plan(3)
+
+    class MyConnection extends HttpConnection {
+      constructor (opts: ConnectionOptions) {
+        super(opts)
+        // @ts-expect-error
+        this.makeRequest = () => {
+          const stream = intoStream(JSON.stringify({ hello: 'world' }))
+          // @ts-expect-error
+          stream.statusCode = 200
+          // @ts-expect-error
+          stream.headers = {
+            'content-type': 'application/json;utf=8',
+            'content-encoding': 'gzip',
+            'content-length': buffer.constants.MAX_STRING_LENGTH + 10,
+            connection: 'keep-alive',
+            date: new Date().toISOString()
+          }
+          stream.on('close', () => t.pass('Stream destroyed'))
+          return {
+            abort () {},
+            removeListener () {},
+            setNoDelay () {},
+            end () {},
+            on (event: string, cb: () => void) {
+              if (event === 'response') {
+                process.nextTick(cb, stream)
+              }
+            }
+          }
+        }
+      }
+    }
+
+    const connection = new MyConnection({
+      url: new URL('http://localhost:9200')
     })
-  } catch (err: any) {
-    t.ok(err instanceof RequestAbortedError, `Not a RequestAbortedError: ${err}`)
-  }
-})
 
-// The nodejs http agent will try to wait for the whole
-// body to arrive before closing the request, so this
-// test might take some time.
-test('Bad content length', async t => {
-  t.plan(2)
-
-  function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
-    const body = JSON.stringify({ hello: 'world' })
-    res.setHeader('Content-Type', 'application/json;utf=8')
-    res.setHeader('Content-Length', body.length + '')
-    res.end(body.slice(0, -5))
-  }
-
-  const [{ port }, server] = await buildServer(handler)
-  const connection = new HttpConnection({
-    url: new URL(`http://localhost:${port}`)
+    try {
+      await connection.request({
+        method: 'GET',
+        path: '/'
+      }, options)
+    } catch (err: any) {
+      t.ok(err instanceof RequestAbortedError, `Not a RequestAbortedError: ${err}`)
+      t.equal(err.message, `The content length (${buffer.constants.MAX_STRING_LENGTH + 10}) is bigger than the maximum allowed string (${buffer.constants.MAX_STRING_LENGTH})`)
+    }
   })
-  try {
-    await connection.request({
-      path: '/hello',
-      method: 'GET'
-    }, options)
-  } catch (err: any) {
-    t.ok(err instanceof ConnectionError, `Not a ConnectionError: ${err}`)
-    t.equal(err.message, 'Response aborted while reading the body')
-  }
-  server.stop()
+
+  t.test('Content length too big custom option (buffer)', async t => {
+    t.plan(3)
+
+    class MyConnection extends HttpConnection {
+      constructor (opts: ConnectionOptions) {
+        super(opts)
+        // @ts-expect-error
+        this.makeRequest = () => {
+          const stream = intoStream(JSON.stringify({ hello: 'world' }))
+          // @ts-expect-error
+          stream.statusCode = 200
+          // @ts-expect-error
+          stream.headers = {
+            'content-type': 'application/json;utf=8',
+            'content-encoding': 'gzip',
+            'content-length': 1100,
+            connection: 'keep-alive',
+            date: new Date().toISOString()
+          }
+          stream.on('close', () => t.pass('Stream destroyed'))
+          return {
+            abort () {},
+            removeListener () {},
+            setNoDelay () {},
+            end () {},
+            on (event: string, cb: () => void) {
+              if (event === 'response') {
+                process.nextTick(cb, stream)
+              }
+            }
+          }
+        }
+      }
+    }
+
+    const connection = new MyConnection({
+      url: new URL('http://localhost:9200')
+    })
+
+    try {
+      await connection.request({
+        method: 'GET',
+        path: '/'
+      }, { ...options, maxCompressedResponseSize: 1000 })
+    } catch (err: any) {
+      t.ok(err instanceof RequestAbortedError, `Not a RequestAbortedError: ${err}`)
+      t.equal(err.message, 'The content length (1100) is bigger than the maximum allowed buffer (1000)')
+    }
+  })
+
+  t.test('Content length too big custom option (string)', async t => {
+    t.plan(3)
+
+    class MyConnection extends HttpConnection {
+      constructor (opts: ConnectionOptions) {
+        super(opts)
+        // @ts-expect-error
+        this.makeRequest = () => {
+          const stream = intoStream(JSON.stringify({ hello: 'world' }))
+          // @ts-expect-error
+          stream.statusCode = 200
+          // @ts-expect-error
+          stream.headers = {
+            'content-type': 'application/json;utf=8',
+            'content-encoding': 'gzip',
+            'content-length': 1100,
+            connection: 'keep-alive',
+            date: new Date().toISOString()
+          }
+          stream.on('close', () => t.pass('Stream destroyed'))
+          return {
+            abort () {},
+            removeListener () {},
+            setNoDelay () {},
+            end () {},
+            on (event: string, cb: () => void) {
+              if (event === 'response') {
+                process.nextTick(cb, stream)
+              }
+            }
+          }
+        }
+      }
+    }
+
+    const connection = new MyConnection({
+      url: new URL('http://localhost:9200')
+    })
+
+    try {
+      await connection.request({
+        method: 'GET',
+        path: '/'
+      }, { ...options, maxResponseSize: 1000 })
+    } catch (err: any) {
+      t.ok(err instanceof RequestAbortedError, `Not a RequestAbortedError: ${err}`)
+      t.equal(err.message, 'The content length (1100) is bigger than the maximum allowed string (1000)')
+    }
+  })
+
+  t.end()
 })
 
-test('Socket destryed while reading the body', async t => {
+test('Socket destroyed while reading the body', async t => {
   t.plan(2)
 
-  function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
+  async function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
     const body = JSON.stringify({ hello: 'world' })
     res.setHeader('Content-Type', 'application/json;utf=8')
     res.setHeader('Content-Length', body.length + '')
     res.write(body.slice(0, -5))
-    setTimeout(() => {
-      res.socket?.destroy()
-    }, 500)
+    await setTimeout(500)
+    res.socket?.destroy()
   }
 
   const [{ port }, server] = await buildServer(handler)
@@ -738,207 +1043,7 @@ test('Socket destryed while reading the body', async t => {
   server.stop()
 })
 
-test('Content length too big (buffer)', async t => {
-  t.plan(3)
-
-  class MyConnection extends HttpConnection {
-    constructor (opts: ConnectionOptions) {
-      super(opts)
-      // @ts-expect-error
-      this.makeRequest = () => {
-        const stream = intoStream(JSON.stringify({ hello: 'world' }))
-        // @ts-expect-error
-        stream.statusCode = 200
-        // @ts-expect-error
-        stream.headers = {
-          'content-type': 'application/json;utf=8',
-          'content-encoding': 'gzip',
-          'content-length': buffer.constants.MAX_LENGTH + 10,
-          connection: 'keep-alive',
-          date: new Date().toISOString()
-        }
-        stream.on('close', () => t.pass('Stream destroyed'))
-        return {
-          abort () {},
-          removeListener () {},
-          setNoDelay () {},
-          end () {},
-          on (event: string, cb: () => void) {
-            if (event === 'response') {
-              process.nextTick(cb, stream)
-            }
-          }
-        }
-      }
-    }
-  }
-
-  const connection = new MyConnection({
-    url: new URL('http://localhost:9200')
-  })
-
-  try {
-    await connection.request({
-      method: 'GET',
-      path: '/'
-    }, options)
-  } catch (err: any) {
-    t.ok(err instanceof RequestAbortedError, `Not a RequestAbortedError: ${err}`)
-    t.equal(err.message, `The content length (${buffer.constants.MAX_LENGTH + 10}) is bigger than the maximum allowed buffer (${buffer.constants.MAX_LENGTH})`)
-  }
-})
-
-test('Content length too big (string)', async t => {
-  t.plan(3)
-
-  class MyConnection extends HttpConnection {
-    constructor (opts: ConnectionOptions) {
-      super(opts)
-      // @ts-expect-error
-      this.makeRequest = () => {
-        const stream = intoStream(JSON.stringify({ hello: 'world' }))
-        // @ts-expect-error
-        stream.statusCode = 200
-        // @ts-expect-error
-        stream.headers = {
-          'content-type': 'application/json;utf=8',
-          'content-encoding': 'gzip',
-          'content-length': buffer.constants.MAX_STRING_LENGTH + 10,
-          connection: 'keep-alive',
-          date: new Date().toISOString()
-        }
-        stream.on('close', () => t.pass('Stream destroyed'))
-        return {
-          abort () {},
-          removeListener () {},
-          setNoDelay () {},
-          end () {},
-          on (event: string, cb: () => void) {
-            if (event === 'response') {
-              process.nextTick(cb, stream)
-            }
-          }
-        }
-      }
-    }
-  }
-
-  const connection = new MyConnection({
-    url: new URL('http://localhost:9200')
-  })
-
-  try {
-    await connection.request({
-      method: 'GET',
-      path: '/'
-    }, options)
-  } catch (err: any) {
-    t.ok(err instanceof RequestAbortedError, `Not a RequestAbortedError: ${err}`)
-    t.equal(err.message, `The content length (${buffer.constants.MAX_STRING_LENGTH + 10}) is bigger than the maximum allowed string (${buffer.constants.MAX_STRING_LENGTH})`)
-  }
-})
-
-test('Content length too big custom option (buffer)', async t => {
-  t.plan(3)
-
-  class MyConnection extends HttpConnection {
-    constructor (opts: ConnectionOptions) {
-      super(opts)
-      // @ts-expect-error
-      this.makeRequest = () => {
-        const stream = intoStream(JSON.stringify({ hello: 'world' }))
-        // @ts-expect-error
-        stream.statusCode = 200
-        // @ts-expect-error
-        stream.headers = {
-          'content-type': 'application/json;utf=8',
-          'content-encoding': 'gzip',
-          'content-length': 1100,
-          connection: 'keep-alive',
-          date: new Date().toISOString()
-        }
-        stream.on('close', () => t.pass('Stream destroyed'))
-        return {
-          abort () {},
-          removeListener () {},
-          setNoDelay () {},
-          end () {},
-          on (event: string, cb: () => void) {
-            if (event === 'response') {
-              process.nextTick(cb, stream)
-            }
-          }
-        }
-      }
-    }
-  }
-
-  const connection = new MyConnection({
-    url: new URL('http://localhost:9200')
-  })
-
-  try {
-    await connection.request({
-      method: 'GET',
-      path: '/'
-    }, { ...options, maxCompressedResponseSize: 1000 })
-  } catch (err: any) {
-    t.ok(err instanceof RequestAbortedError, `Not a RequestAbortedError: ${err}`)
-    t.equal(err.message, 'The content length (1100) is bigger than the maximum allowed buffer (1000)')
-  }
-})
-
-test('Content length too big custom option (string)', async t => {
-  t.plan(3)
-
-  class MyConnection extends HttpConnection {
-    constructor (opts: ConnectionOptions) {
-      super(opts)
-      // @ts-expect-error
-      this.makeRequest = () => {
-        const stream = intoStream(JSON.stringify({ hello: 'world' }))
-        // @ts-expect-error
-        stream.statusCode = 200
-        // @ts-expect-error
-        stream.headers = {
-          'content-type': 'application/json;utf=8',
-          'content-encoding': 'gzip',
-          'content-length': 1100,
-          connection: 'keep-alive',
-          date: new Date().toISOString()
-        }
-        stream.on('close', () => t.pass('Stream destroyed'))
-        return {
-          abort () {},
-          removeListener () {},
-          setNoDelay () {},
-          end () {},
-          on (event: string, cb: () => void) {
-            if (event === 'response') {
-              process.nextTick(cb, stream)
-            }
-          }
-        }
-      }
-    }
-  }
-
-  const connection = new MyConnection({
-    url: new URL('http://localhost:9200')
-  })
-
-  try {
-    await connection.request({
-      method: 'GET',
-      path: '/'
-    }, { ...options, maxResponseSize: 1000 })
-  } catch (err: any) {
-    t.ok(err instanceof RequestAbortedError, `Not a RequestAbortedError: ${err}`)
-    t.equal(err.message, 'The content length (1100) is bigger than the maximum allowed string (1000)')
-  }
-})
-
-test('Compressed responsed should return a buffer as body (gzip)', async t => {
+test('Compressed response should return a buffer as body (gzip)', async t => {
   t.plan(2)
 
   function handler (req: http.IncomingMessage, res: http.ServerResponse) {
@@ -968,7 +1073,7 @@ test('Compressed responsed should return a buffer as body (gzip)', async t => {
   server.stop()
 })
 
-test('Compressed responsed should return a buffer as body (deflate)', async t => {
+test('Compressed response should return a buffer as body (deflate)', async t => {
   t.plan(2)
 
   function handler (req: http.IncomingMessage, res: http.ServerResponse) {
@@ -1001,7 +1106,7 @@ test('Compressed responsed should return a buffer as body (deflate)', async t =>
 test('Body too big custom option (string)', async t => {
   t.plan(2)
 
-  function handler (req: http.IncomingMessage, res: http.ServerResponse) {
+  function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
     res.writeHead(200, {
       'content-type': 'application/json;utf=8',
       'transfer-encoding': 'chunked'
@@ -1031,7 +1136,7 @@ test('Body too big custom option (string)', async t => {
 test('Body too big custom option (buffer)', async t => {
   t.plan(2)
 
-  function handler (req: http.IncomingMessage, res: http.ServerResponse) {
+  function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
     res.writeHead(200, {
       'content-type': 'application/json;utf=8',
       'content-encoding': 'gzip',
@@ -1050,7 +1155,7 @@ test('Body too big custom option (buffer)', async t => {
       method: 'GET',
       path: '/'
     }, { ...options, maxCompressedResponseSize: 1 })
-    t.fail('Shold throw')
+    t.fail('Should throw')
   } catch (err: any) {
     t.ok(err instanceof RequestAbortedError, `Not a RequestAbortedError ${err}`)
     t.equal(err.message, 'The content length (29) is bigger than the maximum allowed buffer (1)')
@@ -1076,27 +1181,12 @@ test('Connection error', async t => {
   }
 })
 
-test('Throw if detects undici agent options', async t => {
-  t.plan(1)
-
-  try {
-    new HttpConnection({
-      url: new URL('http://localhost:9200'),
-      agent: {
-        connections: 42
-      }
-    })
-  } catch (err: any) {
-    t.ok(err instanceof ConfigurationError, `Not a ConfigurationError: ${err}`)
-  }
-})
-
 test('Support mapbox vector tile', async t => {
   t.plan(1)
 
   const mvtContent = 'GoMCCgRtZXRhEikSFAAAAQACAQMBBAAFAgYDBwAIBAkAGAMiDwkAgEAagEAAAP8//z8ADxoOX3NoYXJkcy5mYWlsZWQaD19zaGFyZHMuc2tpcHBlZBoSX3NoYXJkcy5zdWNjZXNzZnVsGg1fc2hhcmRzLnRvdGFsGhlhZ2dyZWdhdGlvbnMuX2NvdW50LmNvdW50GhdhZ2dyZWdhdGlvbnMuX2NvdW50LnN1bRoTaGl0cy50b3RhbC5yZWxhdGlvbhoQaGl0cy50b3RhbC52YWx1ZRoJdGltZWRfb3V0GgR0b29rIgIwACICMAIiCRkAAAAAAAAAACIECgJlcSICOAAogCB4Ag=='
 
-  function handler (req: http.IncomingMessage, res: http.ServerResponse) {
+  function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
     res.setHeader('Content-Type', 'application/vnd.mapbox-vector-tile')
     res.end(Buffer.from(mvtContent, 'base64'))
   }
@@ -1118,7 +1208,7 @@ test('Support Apache Arrow', async t => {
 
   const binaryContent = '/////zABAAAQAAAAAAAKAA4ABgANAAgACgAAAAAABAAQAAAAAAEKAAwAAAAIAAQACgAAAAgAAAAIAAAAAAAAAAIAAAB8AAAABAAAAJ7///8UAAAARAAAAEQAAAAAAAoBRAAAAAEAAAAEAAAAjP///wgAAAAQAAAABAAAAGRhdGUAAAAADAAAAGVsYXN0aWM6dHlwZQAAAAAAAAAAgv///wAAAQAEAAAAZGF0ZQAAEgAYABQAEwASAAwAAAAIAAQAEgAAABQAAABMAAAAVAAAAAAAAwFUAAAAAQAAAAwAAAAIAAwACAAEAAgAAAAIAAAAEAAAAAYAAABkb3VibGUAAAwAAABlbGFzdGljOnR5cGUAAAAAAAAAAAAABgAIAAYABgAAAAAAAgAGAAAAYW1vdW50AAAAAAAA/////7gAAAAUAAAAAAAAAAwAFgAOABUAEAAEAAwAAABgAAAAAAAAAAAABAAQAAAAAAMKABgADAAIAAQACgAAABQAAABYAAAABQAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAQAAAAAAAAAIAAAAAAAAACgAAAAAAAAAMAAAAAAAAAABAAAAAAAAADgAAAAAAAAAKAAAAAAAAAAAAAAAAgAAAAUAAAAAAAAAAAAAAAAAAAAFAAAAAAAAAAAAAAAAAAAAHwAAAAAAAAAAAACgmZkTQAAAAGBmZiBAAAAAAAAAL0AAAADAzMwjQAAAAMDMzCtAHwAAAAAAAADV6yywkgEAANWPBquSAQAA1TPgpZIBAADV17mgkgEAANV7k5uSAQAA/////wAAAAA='
 
-  function handler (req: http.IncomingMessage, res: http.ServerResponse) {
+  function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
     res.setHeader('Content-Type', 'application/vnd.apache.arrow.stream')
     res.end(Buffer.from(binaryContent, 'base64'))
   }
@@ -1135,78 +1225,82 @@ test('Support Apache Arrow', async t => {
   server.stop()
 })
 
-test('Check server fingerprint (success)', async t => {
-  t.plan(1)
+test('CA fingerprint check', t => {
+  t.test('Check server fingerprint (success)', async t => {
+    t.plan(1)
 
-  function handler (req: http.IncomingMessage, res: http.ServerResponse) {
-    res.end('ok')
-  }
+    function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
+      res.end('ok')
+    }
 
-  const [{ port, caFingerprint }, server] = await buildServer(handler, { secure: true })
-  const connection = new HttpConnection({
-    url: new URL(`https://localhost:${port}`),
-    caFingerprint
-  })
-  const res = await connection.request({
-    path: '/hello',
-    method: 'GET'
-  }, options)
-  t.equal(res.body, 'ok')
-  server.stop()
-})
-
-test('Check server fingerprint (different formats)', async t => {
-  t.plan(1)
-
-  function handler (req: http.IncomingMessage, res: http.ServerResponse) {
-    res.end('ok')
-  }
-
-  const [{ port, caFingerprint }, server] = await buildServer(handler, { secure: true })
-
-  let newCaFingerprint = caFingerprint.toLowerCase().replace(/:/g, '')
-
-  const connection = new HttpConnection({
-    url: new URL(`https://localhost:${port}`),
-    caFingerprint: newCaFingerprint,
-  })
-  const res = await connection.request({
-    path: '/hello',
-    method: 'GET'
-  }, options)
-  t.equal(res.body, 'ok')
-  server.stop()
-})
-
-test('Check server fingerprint (failure)', async t => {
-  t.plan(2)
-
-  function handler (req: http.IncomingMessage, res: http.ServerResponse) {
-    res.end('ok')
-  }
-
-  const [{ port }, server] = await buildServer(handler, { secure: true })
-  const connection = new HttpConnection({
-    url: new URL(`https://localhost:${port}`),
-    caFingerprint: 'FO:OB:AR'
-  })
-  try {
-    await connection.request({
+    const [{ port, caFingerprint }, server] = await buildServer(handler, { secure: true })
+    const connection = new HttpConnection({
+      url: new URL(`https://localhost:${port}`),
+      caFingerprint
+    })
+    const res = await connection.request({
       path: '/hello',
       method: 'GET'
     }, options)
-    t.fail('Should throw')
-  } catch (err: any) {
-    t.ok(err instanceof ConnectionError, `Not a ConnectionError: ${err}`)
-    t.equal(err.message, 'Server certificate CA fingerprint does not match the value configured in caFingerprint')
-  }
-  server.stop()
+    t.equal(res.body, 'ok')
+    server.stop()
+  })
+
+  t.test('Check server fingerprint (different formats)', async t => {
+    t.plan(1)
+
+    function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
+      res.end('ok')
+    }
+
+    const [{ port, caFingerprint }, server] = await buildServer(handler, { secure: true })
+
+    let newCaFingerprint = caFingerprint.toLowerCase().replace(/:/g, '')
+
+    const connection = new HttpConnection({
+      url: new URL(`https://localhost:${port}`),
+      caFingerprint: newCaFingerprint,
+    })
+    const res = await connection.request({
+      path: '/hello',
+      method: 'GET'
+    }, options)
+    t.equal(res.body, 'ok')
+    server.stop()
+  })
+
+  t.test('Check server fingerprint (failure)', async t => {
+    t.plan(2)
+
+    function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
+      res.end('ok')
+    }
+
+    const [{ port }, server] = await buildServer(handler, { secure: true })
+    const connection = new HttpConnection({
+      url: new URL(`https://localhost:${port}`),
+      caFingerprint: 'FO:OB:AR'
+    })
+    try {
+      await connection.request({
+        path: '/hello',
+        method: 'GET'
+      }, options)
+      t.fail('Should throw')
+    } catch (err: any) {
+      t.ok(err instanceof ConnectionError, `Not a ConnectionError: ${err}`)
+      t.equal(err.message, 'Server certificate CA fingerprint does not match the value configured in caFingerprint')
+    }
+    server.stop()
+  })
+
+  t.end()
 })
 
-test('Should show local/remote socket addres in case of ECONNRESET', async t => {
+test('Should show local/remote socket address in case of ECONNRESET', async t => {
   t.plan(2)
 
-  function handler (req: http.IncomingMessage, res: http.ServerResponse) {
+  function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
     res.destroy()
   }
 
@@ -1256,7 +1350,7 @@ test('Should decrease the request count if a request never sent', async t => {
 test('as stream', async t => {
   t.plan(2)
 
-  function handler (req: http.IncomingMessage, res: http.ServerResponse) {
+  function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
     res.end('ok')
   }
 
@@ -1280,37 +1374,6 @@ test('as stream', async t => {
     payload += chunk
   }
   t.equal(payload, 'ok')
-  server.stop()
-})
-
-test('Cleanup abort listener', async t => {
-  t.plan(2)
-
-  // uses legacy node-abort-controller polyfill package because the global
-  // AbortController's signal does not let expose an `eventEmitter` property for
-  // us to inspect, but the legacy package does!
-  const controller = new LegacyAbortController()
-
-  function handler (req: http.IncomingMessage, res: http.ServerResponse) {
-    // @ts-expect-error
-    t.equal(controller.signal.eventEmitter.listeners('abort').length, 1)
-    res.end('ok')
-  }
-
-  const [{ port }, server] = await buildServer(handler)
-  const connection = new HttpConnection({
-    url: new URL(`http://localhost:${port}`)
-  })
-
-  await connection.request({
-    path: '/hello',
-    method: 'GET',
-  }, {
-    ...options,
-    signal: controller.signal as AbortSignal
-  })
-  // @ts-expect-error
-  t.equal(controller.signal.eventEmitter.listeners('abort').length, 0)
   server.stop()
 })
 

--- a/test/unit/undici-connection.test.ts
+++ b/test/unit/undici-connection.test.ts
@@ -17,12 +17,13 @@
  * under the License.
  */
 
+import { setTimeout } from 'node:timers/promises'
+import { URL } from 'node:url'
+import * as http from 'node:http'
+import buffer from 'node:buffer'
+import { gzipSync, deflateSync } from 'node:zlib'
+import { Readable } from 'node:stream'
 import { test } from 'tap'
-import { URL } from 'url'
-import * as http from 'http'
-import buffer from 'buffer'
-import { gzipSync, deflateSync } from 'zlib'
-import { Readable } from 'stream'
 import intoStream from 'into-stream'
 import { buildServer } from '../utils'
 import { UndiciConnection, errors, ConnectionOptions } from '../../'
@@ -122,144 +123,152 @@ test('Basic (https with tls agent)', async t => {
   server.stop()
 })
 
-test('Timeout support / 1', async t => {
-  t.plan(1)
+test('Timeout support', t => {
+  t.test('Timeout support / 1', async t => {
+    t.plan(1)
 
-  function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
-    setTimeout(() => res.end('ok'), 1000)
-  }
+    async function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
+      await setTimeout(1000)
+      res.end('ok')
+    }
 
-  const [{ port }, server] = await buildServer(handler)
-  const connection = new UndiciConnection({
-    url: new URL(`http://localhost:${port}`),
-    timeout: 600
-  })
-
-  try {
-    await connection.request({
-      path: '/hello',
-      method: 'GET'
-    }, options)
-  } catch (err: any) {
-    t.ok(err instanceof TimeoutError)
-  }
-  server.stop()
-})
-
-test('Timeout support / 2', async t => {
-  t.plan(2)
-  t.clock.enter()
-  t.teardown(() => t.clock.exit())
-
-  function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
-    res.writeHead(200, { 'content-type': 'text/plain' })
-    setTimeout(() => res.end('ok'), 1000)
-  }
-
-  const [{ port }, server] = await buildServer(handler)
-  const connection = new UndiciConnection({
-    url: new URL(`http://localhost:${port}`),
-    timeout: 600
-  })
-  try {
-    const res = connection.request({
-      path: '/hello',
-      method: 'GET'
-    }, options)
-    t.clock.advance(600)
-    await res
-  } catch (err: any) {
-    t.ok(err instanceof TimeoutError)
-    t.equal(err.message, 'Request timed out')
-  }
-  server.stop()
-})
-
-test('Timeout support / 3', async t => {
-  t.plan(2)
-  t.clock.enter()
-  t.teardown(() => t.clock.exit())
-
-  function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
-    setTimeout(() => res.end('ok'), 1000)
-  }
-
-  const [{ port }, server] = await buildServer(handler)
-  const connection = new UndiciConnection({
-    url: new URL(`http://localhost:${port}`),
-    timeout: 600
-  })
-  try {
-    const res = connection.request({
-      path: '/hello',
-      method: 'GET'
-    }, {
-      timeout: 600,
-      ...options
+    const [{ port }, server] = await buildServer(handler)
+    const connection = new UndiciConnection({
+      url: new URL(`http://localhost:${port}`),
+      timeout: 600
     })
-    t.clock.advance(600)
-    await res
-  } catch (err: any) {
-    t.ok(err instanceof TimeoutError)
-    t.equal(err.message, 'Request timed out')
-  }
-  server.stop()
-})
 
-test('Timeout support / 4', async t => {
-  t.plan(2)
-  t.clock.enter()
-  t.teardown(() => t.clock.exit())
-
-  function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
-    setTimeout(() => res.end('ok'), 1000)
-  }
-
-  const [{ port }, server] = await buildServer(handler)
-  const connection = new UndiciConnection({
-    url: new URL(`http://localhost:${port}`),
-    timeout: 2000
+    try {
+      await connection.request({
+        path: '/hello',
+        method: 'GET'
+      }, options)
+    } catch (err: any) {
+      t.ok(err instanceof TimeoutError)
+    }
+    server.stop()
   })
-  const abortController = new AbortController()
-  try {
-    const res = connection.request({
+
+  t.test('Timeout support / 2', async t => {
+    t.plan(2)
+    t.clock.enter()
+    t.teardown(() => t.clock.exit())
+
+    async function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
+      res.writeHead(200, { 'content-type': 'text/plain' })
+      await setTimeout(1000)
+      res.end('ok')
+    }
+
+    const [{ port }, server] = await buildServer(handler)
+    const connection = new UndiciConnection({
+      url: new URL(`http://localhost:${port}`),
+      timeout: 600
+    })
+    try {
+      const res = connection.request({
+        path: '/hello',
+        method: 'GET'
+      }, options)
+      t.clock.advance(600)
+      await res
+    } catch (err: any) {
+      t.ok(err instanceof TimeoutError)
+      t.equal(err.message, 'Request timed out')
+    }
+    server.stop()
+  })
+
+  t.test('Timeout support / 3', async t => {
+    t.plan(2)
+    t.clock.enter()
+    t.teardown(() => t.clock.exit())
+
+    async function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
+      await setTimeout(1000)
+      res.end('ok')
+    }
+
+    const [{ port }, server] = await buildServer(handler)
+    const connection = new UndiciConnection({
+      url: new URL(`http://localhost:${port}`),
+      timeout: 600
+    })
+    try {
+      const res = connection.request({
+        path: '/hello',
+        method: 'GET'
+      }, {
+        timeout: 600,
+        ...options
+      })
+      t.clock.advance(600)
+      await res
+    } catch (err: any) {
+      t.ok(err instanceof TimeoutError)
+      t.equal(err.message, 'Request timed out')
+    }
+    server.stop()
+  })
+
+  t.test('Timeout support / 4', async t => {
+    t.plan(2)
+    t.clock.enter()
+    t.teardown(() => t.clock.exit())
+
+    async function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
+      await setTimeout(1000)
+      res.end('ok')
+    }
+
+    const [{ port }, server] = await buildServer(handler)
+    const connection = new UndiciConnection({
+      url: new URL(`http://localhost:${port}`),
+      timeout: 2000
+    })
+    const abortController = new AbortController()
+    try {
+      const res = connection.request({
+        path: '/hello',
+        method: 'GET',
+      }, {
+        signal: abortController.signal,
+        timeout: 50,
+        ...options
+      })
+      t.clock.advance(1000)
+      await res
+      t.fail('Timeout was not reached')
+    } catch (err: any) {
+      t.ok(err instanceof TimeoutError)
+      t.equal(err.message, 'Request timed out')
+    }
+    server.stop()
+  })
+
+  t.test('Timeout support / 5', async t => {
+    t.plan(1)
+
+    function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
+      res.end('ok')
+    }
+
+    const [{ port }, server] = await buildServer(handler)
+    const connection = new UndiciConnection({
+      url: new URL(`http://localhost:${port}`)
+    })
+    const res = await connection.request({
       path: '/hello',
       method: 'GET',
     }, {
-      signal: abortController.signal,
       timeout: 50,
       ...options
     })
-    t.clock.advance(1000)
-    await res
-    t.fail('Timeout was not reached')
-  } catch (err: any) {
-    t.ok(err instanceof TimeoutError)
-    t.equal(err.message, 'Request timed out')
-  }
-  server.stop()
-})
-
-test('Timeout support / 5', async t => {
-  t.plan(1)
-
-  function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
-    res.end('ok')
-  }
-
-  const [{ port }, server] = await buildServer(handler)
-  const connection = new UndiciConnection({
-    url: new URL(`http://localhost:${port}`)
+    t.equal(res.body, 'ok')
+    server.stop()
   })
-  const res = await connection.request({
-    path: '/hello',
-    method: 'GET',
-  }, {
-    timeout: 50,
-    ...options
-  })
-  t.equal(res.body, 'ok')
-  server.stop()
+
+  t.end()
 })
 
 test('Should concatenate the querystring', async t => {
@@ -368,8 +377,9 @@ test('Send body as stream', async t => {
 test('Should not close a connection if there are open requests', async t => {
   t.plan(1)
 
-  function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
-    setTimeout(() => res.end('ok'), 100)
+  async function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
+    await setTimeout(100)
+    res.end('ok')
   }
 
   const [{ port }, server] = await buildServer(handler)
@@ -459,146 +469,307 @@ test('Should disallow two-byte characters in URL path', async t => {
   }
 })
 
-test('Abort a request syncronously', async t => {
-  t.plan(2)
+test('Abort request', t => {
+  t.test('Abort a request syncronously', async t => {
+    t.plan(2)
 
-  function handler (_req: http.IncomingMessage, _res: http.ServerResponse) {
-    t.fail('The server should not be contacted')
-  }
+    function handler (_req: http.IncomingMessage, _res: http.ServerResponse) {
+      t.fail('The server should not be contacted')
+    }
 
-  const [{ port }, server] = await buildServer(handler)
-  const connection = new UndiciConnection({
-    url: new URL(`http://localhost:${port}`),
-    headers: { 'x-foo': 'bar' }
+    const [{ port }, server] = await buildServer(handler)
+    const connection = new UndiciConnection({
+      url: new URL(`http://localhost:${port}`),
+      headers: { 'x-foo': 'bar' }
+    })
+
+    const controller = new AbortController()
+    connection.request({
+      path: '/hello',
+      method: 'GET',
+    }, {
+      signal: controller.signal,
+      ...options
+    }).catch(err => {
+      t.ok(err instanceof RequestAbortedError)
+      t.ok(controller.signal.aborted, 'Signal should be aborted')
+      server.stop()
+    })
+
+    controller.abort()
+    await connection.close()
   })
 
-  const controller = new AbortController()
-  connection.request({
-    path: '/hello',
-    method: 'GET',
-  }, {
-    signal: controller.signal,
-    ...options
-  }).catch(err => {
-    t.ok(err instanceof RequestAbortedError)
-    t.ok(controller.signal.aborted, 'Signal should be aborted')
+  t.test('Abort a request asyncronously', async t => {
+    t.plan(1)
+
+    function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
+      // might be called or not
+      res.end('ok')
+    }
+
+    const [{ port }, server] = await buildServer(handler)
+    const connection = new UndiciConnection({
+      url: new URL(`http://localhost:${port}`),
+      headers: { 'x-foo': 'bar' }
+    })
+
+    const controller = new AbortController()
+    setImmediate(() => controller.abort())
+    try {
+      await connection.request({
+        path: '/hello',
+        method: 'GET',
+      }, {
+        signal: controller.signal,
+        ...options
+      })
+    } catch (err: any) {
+      t.ok(err instanceof RequestAbortedError)
+    }
+
+    await connection.close()
     server.stop()
   })
 
-  controller.abort()
-  await connection.close()
-})
+  t.test('Abort with a slow body', async t => {
+    t.plan(1)
 
-test('Abort a request asyncronously', async t => {
-  t.plan(1)
-
-  function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
-    // might be called or not
-    res.end('ok')
-  }
-
-  const [{ port }, server] = await buildServer(handler)
-  const connection = new UndiciConnection({
-    url: new URL(`http://localhost:${port}`),
-    headers: { 'x-foo': 'bar' }
-  })
-
-  const controller = new AbortController()
-  setImmediate(() => controller.abort())
-  try {
-    await connection.request({
-      path: '/hello',
-      method: 'GET',
-    }, {
-      signal: controller.signal,
-      ...options
+    const controller = new AbortController()
+    function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
+      res.end('ok')
+    }
+    const [{ port }, server] = await buildServer(handler)
+    const connection = new UndiciConnection({
+      url: new URL(`http://localhost:${port}`)
     })
-  } catch (err: any) {
-    t.ok(err instanceof RequestAbortedError)
-  }
 
-  await connection.close()
-  server.stop()
-})
+    const slowBody = new Readable({
+      async read (_size: number) {
+        await setTimeout(1000, { ref: false })
+        this.push(null) // EOF
+      }
+    })
 
-test('Abort with a slow body', async t => {
-  t.plan(1)
-
-  const controller = new AbortController()
-  function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
-    res.end('ok')
-  }
-  const [{ port }, server] = await buildServer(handler)
-  const connection = new UndiciConnection({
-    url: new URL(`http://localhost:${port}`)
+    setImmediate(() => controller.abort())
+    try {
+      await connection.request({
+        method: 'GET',
+        path: '/',
+        // @ts-ignore
+        body: slowBody,
+      }, {
+        signal: controller.signal,
+        ...options
+      })
+    } catch (err: any) {
+      t.ok(err instanceof RequestAbortedError)
+    }
+    server.stop()
   })
 
-  const slowBody = new Readable({
-    read (_size: number) {
-      setTimeout(() => {
-        this.push('{"size":1, "query":{"match_all":{}}}')
-        this.push(null) // EOF
-      }, 1000).unref()
+  t.end()
+})
+
+test('Content length', t => {
+  // The nodejs http agent will try to wait for the whole
+  // body to arrive before closing the request, so this
+  // test might take some time.
+  t.test('Bad content length', async t => {
+    t.plan(2)
+
+    function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
+      const body = JSON.stringify({ hello: 'world' })
+      res.setHeader('Content-Type', 'application/json;utf=8')
+      res.setHeader('Content-Length', body.length + '')
+      res.end(body.slice(0, -5))
+    }
+
+    const [{ port }, server] = await buildServer(handler)
+    const connection = new UndiciConnection({
+      url: new URL(`http://localhost:${port}`)
+    })
+    try {
+      await connection.request({
+        path: '/hello',
+        method: 'GET'
+      }, options)
+    } catch (err: any) {
+      t.ok(err instanceof ConnectionError)
+      t.equal(err.message, 'other side closed')
+    }
+    server.stop()
+  })
+
+  t.test('Content length too big (buffer)', async t => {
+    t.plan(2)
+
+    class MyConnection extends UndiciConnection {
+      constructor (opts: ConnectionOptions) {
+        super(opts)
+        this.pool = {
+          // @ts-expect-error
+          request () {
+            const stream = intoStream(JSON.stringify({ hello: 'world' }))
+            const statusCode = 200
+            const headers = {
+              'content-type': 'application/json;utf=8',
+              'content-encoding': 'gzip',
+              'content-length': buffer.constants.MAX_LENGTH + 10,
+              connection: 'keep-alive',
+              date: new Date().toISOString()
+            }
+            return { body: stream, statusCode, headers }
+          }
+        }
+      }
+    }
+
+    const connection = new MyConnection({
+      url: new URL('http://localhost:9200')
+    })
+
+    try {
+      await connection.request({
+        method: 'GET',
+        path: '/'
+      }, options)
+    } catch (err: any) {
+      t.ok(err instanceof RequestAbortedError)
+      t.equal(err.message, `The content length (${buffer.constants.MAX_LENGTH + 10}) is bigger than the maximum allowed buffer (${buffer.constants.MAX_LENGTH})`)
     }
   })
 
-  setImmediate(() => controller.abort())
-  try {
-    await connection.request({
-      method: 'GET',
-      path: '/',
-      // @ts-ignore
-      body: slowBody,
-    }, {
-      signal: controller.signal,
-      ...options
+  t.test('Content length too big (string)', async t => {
+    t.plan(2)
+
+    class MyConnection extends UndiciConnection {
+      constructor (opts: ConnectionOptions) {
+        super(opts)
+        this.pool = {
+          // @ts-expect-error
+          request () {
+            const stream = intoStream(JSON.stringify({ hello: 'world' }))
+            const statusCode = 200
+            const headers = {
+              'content-type': 'application/json;utf=8',
+              'content-encoding': 'gzip',
+              'content-length': buffer.constants.MAX_STRING_LENGTH + 10,
+              connection: 'keep-alive',
+              date: new Date().toISOString()
+            }
+            return { body: stream, statusCode, headers }
+          }
+        }
+      }
+    }
+
+    const connection = new MyConnection({
+      url: new URL('http://localhost:9200')
     })
-  } catch (err: any) {
-    t.ok(err instanceof RequestAbortedError)
-  }
-  server.stop()
-})
 
-// The nodejs http agent will try to wait for the whole
-// body to arrive before closing the request, so this
-// test might take some time.
-test('Bad content length', async t => {
-  t.plan(2)
-
-  function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
-    const body = JSON.stringify({ hello: 'world' })
-    res.setHeader('Content-Type', 'application/json;utf=8')
-    res.setHeader('Content-Length', body.length + '')
-    res.end(body.slice(0, -5))
-  }
-
-  const [{ port }, server] = await buildServer(handler)
-  const connection = new UndiciConnection({
-    url: new URL(`http://localhost:${port}`)
+    try {
+      await connection.request({
+        method: 'GET',
+        path: '/'
+      }, options)
+    } catch (err: any) {
+      t.ok(err instanceof RequestAbortedError)
+      t.equal(err.message, `The content length (${buffer.constants.MAX_STRING_LENGTH + 10}) is bigger than the maximum allowed string (${buffer.constants.MAX_STRING_LENGTH})`)
+    }
   })
-  try {
-    await connection.request({
-      path: '/hello',
-      method: 'GET'
-    }, options)
-  } catch (err: any) {
-    t.ok(err instanceof ConnectionError)
-    t.equal(err.message, 'other side closed')
-  }
-  server.stop()
+
+  t.test('Content length too big custom option (buffer)', async t => {
+    t.plan(2)
+
+    class MyConnection extends UndiciConnection {
+      constructor (opts: ConnectionOptions) {
+        super(opts)
+        this.pool = {
+          // @ts-expect-error
+          request () {
+            const stream = intoStream(JSON.stringify({ hello: 'world' }))
+            const statusCode = 200
+            const headers = {
+              'content-type': 'application/json;utf=8',
+              'content-encoding': 'gzip',
+              'content-length': 1100,
+              connection: 'keep-alive',
+              date: new Date().toISOString()
+            }
+            return { body: stream, statusCode, headers }
+          }
+        }
+      }
+    }
+
+    const connection = new MyConnection({
+      url: new URL('http://localhost:9200')
+    })
+
+    try {
+      await connection.request({
+        method: 'GET',
+        path: '/'
+      }, { ...options, maxCompressedResponseSize: 1000 })
+    } catch (err: any) {
+      t.ok(err instanceof RequestAbortedError)
+      t.equal(err.message, 'The content length (1100) is bigger than the maximum allowed buffer (1000)')
+    }
+  })
+
+  t.test('Content length too big custom option (string)', async t => {
+    t.plan(2)
+
+    class MyConnection extends UndiciConnection {
+      constructor (opts: ConnectionOptions) {
+        super(opts)
+        this.pool = {
+          // @ts-expect-error
+          request () {
+            const stream = intoStream(JSON.stringify({ hello: 'world' }))
+            const statusCode = 200
+            const headers = {
+              'content-type': 'application/json;utf=8',
+              'content-encoding': 'gzip',
+              'content-length': 1100,
+              connection: 'keep-alive',
+              date: new Date().toISOString()
+            }
+            return { body: stream, statusCode, headers }
+          }
+        }
+      }
+    }
+
+    const connection = new MyConnection({
+      url: new URL('http://localhost:9200')
+    })
+
+    try {
+      await connection.request({
+        method: 'GET',
+        path: '/'
+      }, { ...options, maxResponseSize: 1000 })
+    } catch (err: any) {
+      t.ok(err instanceof RequestAbortedError)
+      t.equal(err.message, 'The content length (1100) is bigger than the maximum allowed string (1000)')
+    }
+  })
+
+  t.end()
 })
 
-test('Socket destryed while reading the body', async t => {
+test('Socket destroyed while reading the body', async t => {
   t.plan(2)
 
-  function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
+  async function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
     const body = JSON.stringify({ hello: 'world' })
     res.setHeader('Content-Type', 'application/json;utf=8')
     res.setHeader('Content-Length', body.length + '')
     res.write(body.slice(0, -5))
-    setTimeout(() => {
-      res.socket?.destroy()
-    }, 500)
+    await setTimeout(500)
+    res.socket?.destroy()
   }
 
   const [{ port }, server] = await buildServer(handler)
@@ -615,175 +786,21 @@ test('Socket destryed while reading the body', async t => {
     t.equal(err.message, 'other side closed')
   }
   server.stop()
-})
-
-test('Content length too big (buffer)', async t => {
-  t.plan(2)
-
-  class MyConnection extends UndiciConnection {
-    constructor (opts: ConnectionOptions) {
-      super(opts)
-      this.pool = {
-        // @ts-expect-error
-        request () {
-          const stream = intoStream(JSON.stringify({ hello: 'world' }))
-          const statusCode = 200
-          const headers = {
-            'content-type': 'application/json;utf=8',
-            'content-encoding': 'gzip',
-            'content-length': buffer.constants.MAX_LENGTH + 10,
-            connection: 'keep-alive',
-            date: new Date().toISOString()
-          }
-          return { body: stream, statusCode, headers }
-        }
-      }
-    }
-  }
-
-  const connection = new MyConnection({
-    url: new URL('http://localhost:9200')
-  })
-
-  try {
-    await connection.request({
-      method: 'GET',
-      path: '/'
-    }, options)
-  } catch (err: any) {
-    t.ok(err instanceof RequestAbortedError)
-    t.equal(err.message, `The content length (${buffer.constants.MAX_LENGTH + 10}) is bigger than the maximum allowed buffer (${buffer.constants.MAX_LENGTH})`)
-  }
-})
-
-test('Content length too big (string)', async t => {
-  t.plan(2)
-
-  class MyConnection extends UndiciConnection {
-    constructor (opts: ConnectionOptions) {
-      super(opts)
-      this.pool = {
-        // @ts-expect-error
-        request () {
-          const stream = intoStream(JSON.stringify({ hello: 'world' }))
-          const statusCode = 200
-          const headers = {
-            'content-type': 'application/json;utf=8',
-            'content-encoding': 'gzip',
-            'content-length': buffer.constants.MAX_STRING_LENGTH + 10,
-            connection: 'keep-alive',
-            date: new Date().toISOString()
-          }
-          return { body: stream, statusCode, headers }
-        }
-      }
-    }
-  }
-
-  const connection = new MyConnection({
-    url: new URL('http://localhost:9200')
-  })
-
-  try {
-    await connection.request({
-      method: 'GET',
-      path: '/'
-    }, options)
-  } catch (err: any) {
-    t.ok(err instanceof RequestAbortedError)
-    t.equal(err.message, `The content length (${buffer.constants.MAX_STRING_LENGTH + 10}) is bigger than the maximum allowed string (${buffer.constants.MAX_STRING_LENGTH})`)
-  }
-})
-
-test('Content length too big custom option (buffer)', async t => {
-  t.plan(2)
-
-  class MyConnection extends UndiciConnection {
-    constructor (opts: ConnectionOptions) {
-      super(opts)
-      this.pool = {
-        // @ts-expect-error
-        request () {
-          const stream = intoStream(JSON.stringify({ hello: 'world' }))
-          const statusCode = 200
-          const headers = {
-            'content-type': 'application/json;utf=8',
-            'content-encoding': 'gzip',
-            'content-length': 1100,
-            connection: 'keep-alive',
-            date: new Date().toISOString()
-          }
-          return { body: stream, statusCode, headers }
-        }
-      }
-    }
-  }
-
-  const connection = new MyConnection({
-    url: new URL('http://localhost:9200')
-  })
-
-  try {
-    await connection.request({
-      method: 'GET',
-      path: '/'
-    }, { ...options, maxCompressedResponseSize: 1000 })
-  } catch (err: any) {
-    t.ok(err instanceof RequestAbortedError)
-    t.equal(err.message, 'The content length (1100) is bigger than the maximum allowed buffer (1000)')
-  }
-})
-
-test('Content length too big custom option (string)', async t => {
-  t.plan(2)
-
-  class MyConnection extends UndiciConnection {
-    constructor (opts: ConnectionOptions) {
-      super(opts)
-      this.pool = {
-        // @ts-expect-error
-        request () {
-          const stream = intoStream(JSON.stringify({ hello: 'world' }))
-          const statusCode = 200
-          const headers = {
-            'content-type': 'application/json;utf=8',
-            'content-encoding': 'gzip',
-            'content-length': 1100,
-            connection: 'keep-alive',
-            date: new Date().toISOString()
-          }
-          return { body: stream, statusCode, headers }
-        }
-      }
-    }
-  }
-
-  const connection = new MyConnection({
-    url: new URL('http://localhost:9200')
-  })
-
-  try {
-    await connection.request({
-      method: 'GET',
-      path: '/'
-    }, { ...options, maxResponseSize: 1000 })
-  } catch (err: any) {
-    t.ok(err instanceof RequestAbortedError)
-    t.equal(err.message, 'The content length (1100) is bigger than the maximum allowed string (1000)')
-  }
 })
 
 test('Body too big custom option (string)', async t => {
   t.plan(2)
 
-  function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
+  async function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
     res.writeHead(200, {
       'content-type': 'application/json;utf=8',
       'transfer-encoding': 'chunked'
     })
     res.write('{"hello":')
-    setTimeout(() => res.write('"world"}'), 500)
-    setTimeout(() => res.end(), 1000)
+    await setTimeout(500)
+    res.write('"world"}')
+    await setTimeout(1000)
+    res.end()
   }
 
   const [{ port }, server] = await buildServer(handler)
@@ -808,15 +825,17 @@ test('Body too big custom option (string)', async t => {
 test('Body too big custom option (buffer)', async t => {
   t.plan(2)
 
-  function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
+  async function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
     res.writeHead(200, {
       'content-type': 'application/json;utf=8',
       'content-encoding': 'gzip',
       'transfer-encoding': 'chunked'
     })
     res.write(gzipSync('{"hello":'))
-    setTimeout(() => res.write(gzipSync('"world"}')), 500)
-    setTimeout(() => res.end(), 1000)
+    await setTimeout(500)
+    res.write(gzipSync('"world"}'))
+    await setTimeout(1000)
+    res.end()
   }
 
   const [{ port }, server] = await buildServer(handler)
@@ -1005,105 +1024,109 @@ test('Support Apache Arrow', async t => {
   server.stop()
 })
 
-test('Check server fingerprint (success)', async t => {
-  t.plan(1)
+test('CA fingerprint check', t => {
+  t.test('Check server fingerprint (success)', async t => {
+    t.plan(1)
 
-  function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
-    res.end('ok')
-  }
+    function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
+      res.end('ok')
+    }
 
-  const [{ port, caFingerprint }, server] = await buildServer(handler, { secure: true })
-  const connection = new UndiciConnection({
-    url: new URL(`https://localhost:${port}`),
-    caFingerprint
-  })
-  const res = await connection.request({
-    path: '/hello',
-    method: 'GET'
-  }, options)
-  t.equal(res.body, 'ok')
-  server.stop()
-})
-
-test('Check server fingerprint (different formats)', async t => {
-  t.plan(1)
-
-  function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
-    res.end('ok')
-  }
-
-  const [{ port, caFingerprint }, server] = await buildServer(handler, { secure: true })
-
-  let newCaFingerprint = caFingerprint.toLowerCase().replace(/:/g, '')
-
-  const connection = new UndiciConnection({
-    url: new URL(`https://localhost:${port}`),
-    caFingerprint: newCaFingerprint
-  })
-  const res = await connection.request({
-    path: '/hello',
-    method: 'GET'
-  }, options)
-  t.equal(res.body, 'ok')
-  server.stop()
-})
-
-test('Check server fingerprint (failure)', async t => {
-  t.plan(2)
-
-  function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
-    res.end('ok')
-  }
-
-  const [{ port }, server] = await buildServer(handler, { secure: true })
-  const connection = new UndiciConnection({
-    url: new URL(`https://localhost:${port}`),
-    caFingerprint: 'FO:OB:AR'
-  })
-  try {
-    await connection.request({
+    const [{ port, caFingerprint }, server] = await buildServer(handler, { secure: true })
+    const connection = new UndiciConnection({
+      url: new URL(`https://localhost:${port}`),
+      caFingerprint
+    })
+    const res = await connection.request({
       path: '/hello',
       method: 'GET'
     }, options)
-    t.fail('Should throw')
-  } catch (err: any) {
-    t.ok(err instanceof ConnectionError)
-    t.equal(err.message, 'Server certificate CA fingerprint does not match the value configured in caFingerprint')
-  }
-  server.stop()
-})
-
-test('Multiple requests to same connection should skip fingerprint check when session is reused', async t => {
-  // fingerprint matching can, and must, be skipped when a TLS session is being reused
-  // see https://nodejs.org/api/tls.html#session-resumption
-  // this tests that subsequent requests sent to the same connection will not fail due to
-  // a fingerprint match test failing.
-  const runs = 4
-  t.plan(runs)
-
-  function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
-    res.end('ok')
-  }
-
-  const [{ port, caFingerprint }, server] = await buildServer(handler, { secure: true })
-  const connection = new UndiciConnection({
-    url: new URL(`https://localhost:${port}`),
-    caFingerprint,
+    t.equal(res.body, 'ok')
+    server.stop()
   })
 
-  for (let i = 0; i < runs; i++) {
+  t.test('Check server fingerprint (different formats)', async t => {
+    t.plan(1)
+
+    function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
+      res.end('ok')
+    }
+
+    const [{ port, caFingerprint }, server] = await buildServer(handler, { secure: true })
+
+    let newCaFingerprint = caFingerprint.toLowerCase().replace(/:/g, '')
+
+    const connection = new UndiciConnection({
+      url: new URL(`https://localhost:${port}`),
+      caFingerprint: newCaFingerprint
+    })
+    const res = await connection.request({
+      path: '/hello',
+      method: 'GET'
+    }, options)
+    t.equal(res.body, 'ok')
+    server.stop()
+  })
+
+  t.test('Check server fingerprint (failure)', async t => {
+    t.plan(2)
+
+    function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
+      res.end('ok')
+    }
+
+    const [{ port }, server] = await buildServer(handler, { secure: true })
+    const connection = new UndiciConnection({
+      url: new URL(`https://localhost:${port}`),
+      caFingerprint: 'FO:OB:AR'
+    })
     try {
-      const res = await connection.request({
-        path: `/hello-${i}`,
+      await connection.request({
+        path: '/hello',
         method: 'GET'
       }, options)
-      t.equal(res.body, 'ok')
-    } catch {
-      t.fail('This should never be reached')
+      t.fail('Should throw')
+    } catch (err: any) {
+      t.ok(err instanceof ConnectionError)
+      t.equal(err.message, 'Server certificate CA fingerprint does not match the value configured in caFingerprint')
     }
-  }
+    server.stop()
+  })
 
-  server.stop()
+  t.test('Multiple requests to same connection should skip fingerprint check when session is reused', async t => {
+    // fingerprint matching can, and must, be skipped when a TLS session is being reused
+    // see https://nodejs.org/api/tls.html#session-resumption
+    // this tests that subsequent requests sent to the same connection will not fail due to
+    // a fingerprint match test failing.
+    const runs = 4
+    t.plan(runs)
+
+    function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
+      res.end('ok')
+    }
+
+    const [{ port, caFingerprint }, server] = await buildServer(handler, { secure: true })
+    const connection = new UndiciConnection({
+      url: new URL(`https://localhost:${port}`),
+      caFingerprint,
+    })
+
+    for (let i = 0; i < runs; i++) {
+      try {
+        const res = await connection.request({
+          path: `/hello-${i}`,
+          method: 'GET'
+        }, options)
+        t.equal(res.body, 'ok')
+      } catch {
+        t.fail('This should never be reached')
+      }
+    }
+
+    server.stop()
+  })
+
+  t.end()
 })
 
 test('Should show local/remote socket addres in case of ECONNRESET', async t => {

--- a/test/utils/buildServer.ts
+++ b/test/utils/buildServer.ts
@@ -65,7 +65,7 @@ export default function buildServer (handler: ServerHandler, opts: Options = {})
     process.exit(1)
   })
 
-  return new Promise((resolve, reject) => {
+  return new Promise((resolve) => {
     server.listen(0, () => {
       // @ts-expect-error
       const port = server.address().port


### PR DESCRIPTION
[The Elasticsearch docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-network.html#_http_client_configuration) make it clear that it is better to wait for a response than to time out the request.
