### PR TITLE
Drop 30-second timeout default from BaseConnection

### DIFF
--- a/src/Transport.ts
+++ b/src/Transport.ts
@@ -97,7 +97,7 @@ export interface TransportOptions {
   connectionPool: BaseConnectionPool
   serializer?: Serializer
   maxRetries?: number
-  requestTimeout?: number | string
+  requestTimeout?: number | string | null
   retryOnTimeout?: boolean
   compression?: boolean
   sniffInterval?: number | boolean

--- a/src/connection/BaseConnection.ts
+++ b/src/connection/BaseConnection.ts
@@ -112,7 +112,6 @@ export default class BaseConnection {
     this.id = opts.id ?? stripAuth(opts.url.href)
     this.headers = prepareHeaders(opts.headers, opts.auth)
     this.timeout = opts.timeout ?? null
-    this.timeout = opts.timeout ?? 30000
     this.deadCount = 0
     this.resurrectTimeout = 0
     this.weight = 0

--- a/src/connection/UndiciConnection.ts
+++ b/src/connection/UndiciConnection.ts
@@ -79,8 +79,8 @@ export default class Connection extends BaseConnection {
       connections: 256,
       // only set a timeout if it has a value; default to no timeout
       // see https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-network.html#_http_client_configuration
-      headersTimeout: this.timeout ?? undefined,
-      bodyTimeout: this.timeout ?? undefined,
+      headersTimeout: this.timeout ?? 0,
+      bodyTimeout: this.timeout ?? 0,
       ...opts.agent
     }
 

--- a/test/unit/undici-connection.test.ts
+++ b/test/unit/undici-connection.test.ts
@@ -152,8 +152,9 @@ test('Timeout support', t => {
 
   t.test('Timeout support / 2', async t => {
     t.plan(2)
-    t.clock.enter()
-    t.teardown(() => t.clock.exit())
+
+    const clock = FakeTimers.install({ toFake: ['setTimeout'] })
+    t.teardown(() => clock.uninstall())
 
     async function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
       res.writeHead(200, { 'content-type': 'text/plain' })
@@ -171,7 +172,7 @@ test('Timeout support', t => {
         path: '/hello',
         method: 'GET'
       }, options)
-      t.clock.advance(600)
+      clock.tick(600)
       await res
     } catch (err: any) {
       t.ok(err instanceof TimeoutError)
@@ -182,8 +183,8 @@ test('Timeout support', t => {
 
   t.test('Timeout support / 3', async t => {
     t.plan(2)
-    t.clock.enter()
-    t.teardown(() => t.clock.exit())
+    const clock = FakeTimers.install({ toFake: ['setTimeout'] })
+    t.teardown(() => clock.uninstall())
 
     async function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
       await setTimeout(1000)
@@ -203,7 +204,7 @@ test('Timeout support', t => {
         timeout: 600,
         ...options
       })
-      t.clock.advance(600)
+      clock.tick(600)
       await res
     } catch (err: any) {
       t.ok(err instanceof TimeoutError)
@@ -214,8 +215,8 @@ test('Timeout support', t => {
 
   t.test('Timeout support / 4', async t => {
     t.plan(2)
-    t.clock.enter()
-    t.teardown(() => t.clock.exit())
+    const clock = FakeTimers.install({ toFake: ['setTimeout'] })
+    t.teardown(() => clock.uninstall())
 
     async function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
       await setTimeout(1000)
@@ -237,7 +238,7 @@ test('Timeout support', t => {
         timeout: 50,
         ...options
       })
-      t.clock.advance(1000)
+      clock.tick(1000)
       await res
       t.fail('Timeout was not reached')
     } catch (err: any) {


### PR DESCRIPTION
Missed a spot when removing the default timeout value in https://github.com/elastic/elastic-transport-js/pull/201.
