### PR TITLE
Revert Undici to v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "ms": "^2.1.3",
     "secure-json-parse": "^3.0.1",
     "tslib": "^2.8.1",
-    "undici": "^7.2.3"
+    "undici": "^6.21.1"
   },
   "tap": {
     "allow-incomplete-coverage": true,


### PR DESCRIPTION
Although all tests pass successfully, Undici v7 officially dropped support for  Node.js v18, which we're not ready to drop in 8.x yet.
