### PR TITLE
Handle server closing connection after response body is sent

### DIFF
--- a/src/connection/HttpConnection.ts
+++ b/src/connection/HttpConnection.ts
@@ -118,7 +118,6 @@ export default class HttpConnection extends BaseConnection {
       // we only know a request is truly finished when one of the following is true:
       // - request.finish and response.end have both fired (success)
       // - request.error has fired (failure)
-      // - request.close has fired before its listener has been removed (failure)
       // - response.close has fired (failure)
       let responseEnded = false
       let requestFinished = false

--- a/src/connection/HttpConnection.ts
+++ b/src/connection/HttpConnection.ts
@@ -251,6 +251,8 @@ export default class HttpConnection extends BaseConnection {
 
         if (code === 'ECONNRESET') {
           message += ` - Local: ${request.socket?.localAddress ?? 'unknown'}:${request.socket?.localPort ?? 'unknown'}, Remote: ${request.socket?.remoteAddress ?? 'unknown'}:${request.socket?.remotePort ?? 'unknown'}`
+        } else if (code === 'EPIPE') {
+          message = 'Response aborted while reading the body'
         }
         return reject(new ConnectionError(message))
       }

--- a/src/connection/HttpConnection.ts
+++ b/src/connection/HttpConnection.ts
@@ -242,9 +242,7 @@ export default class HttpConnection extends BaseConnection {
 
         // ignore this error, it means we got a response body for a request that didn't expect a body (e.g. HEAD)
         // rather than failing, let it return a response with an empty string as body
-        if (code === 'HPE_INVALID_CONSTANT' || message.startsWith('Parse Error: Expected HTTP/')) {
-          return
-        }
+        if (code === 'HPE_INVALID_CONSTANT' && message.startsWith('Parse Error: Expected HTTP/')) return
 
         cleanListeners()
         if (name === 'RequestAbortedError') {
@@ -253,8 +251,6 @@ export default class HttpConnection extends BaseConnection {
 
         if (code === 'ECONNRESET') {
           message += ` - Local: ${request.socket?.localAddress ?? 'unknown'}:${request.socket?.localPort ?? 'unknown'}, Remote: ${request.socket?.remoteAddress ?? 'unknown'}:${request.socket?.remotePort ?? 'unknown'}`
-        } else if (code === 'EPIPE') {
-          message = 'Connection closed early by server'
         }
         return reject(new ConnectionError(message))
       }

--- a/test/unit/http-connection.test.ts
+++ b/test/unit/http-connection.test.ts
@@ -1092,7 +1092,10 @@ test('Connection closed while sending the request body as stream (EPIPE)', async
     t.fail('ConnectionError should have been caught')
   } catch (err: any) {
     t.ok(err instanceof ConnectionError, `Not a ConnectionError: ${err}`)
-    t.equal(err.message, 'Response aborted while reading the body')
+    t.ok(
+      err.message === 'Response aborted while reading the body' || err.message.startsWith('write ECONNRESET - Local:'),
+      `Unexpected error message: ${err.message}`
+    )
   }
 
   server.stop()
@@ -1127,7 +1130,10 @@ test('Connection closed while sending the request body as string (EPIPE)', async
     t.fail('ConnectionError should have been caught')
   } catch (err: any) {
     t.ok(err instanceof ConnectionError, `Not a ConnectionError: ${err}`)
-    t.equal(err.message, 'Response aborted while reading the body')
+    t.ok(
+      err.message === 'Response aborted while reading the body' || err.message.startsWith('write ECONNRESET - Local:'),
+      `Unexpected error message: ${err.message}`
+    )
   }
 
   server.stop()

--- a/test/unit/http-connection.test.ts
+++ b/test/unit/http-connection.test.ts
@@ -1053,6 +1053,86 @@ test('Socket destroyed while reading the body', async t => {
   server.stop()
 })
 
+test('Connection closed while sending the request body as stream (EPIPE)', async t => {
+  t.plan(2)
+
+  let dataCounter = 0
+  function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
+    dataCounter++
+    if (dataCounter === 1) {
+      res.writeHead(413, { 'Connection': 'close' });
+      res.end('Payload Too Large');
+    } else {
+      t.fail('Request should stop trying to send data')
+    }
+  }
+  const [{ port }, server] = await buildServer(handler)
+
+  const connection = new HttpConnection({
+    url: new URL(`http://localhost:${port}`),
+  })
+
+  const body = new Readable({
+    async read (_size: number) {
+      await setTimeout(500)
+      // run one large request where data will be received by socket in multiple chunks
+      this.push('x'.repeat(99999999))
+      await setTimeout(500)
+      this.push(null) // EOF
+    }
+  })
+
+  try {
+    // run one large request where data will be received by socket in multiple chunks
+    await connection.request({
+      path: '/hello',
+      method: 'POST',
+      body
+    }, options)
+    t.fail('ConnectionError should have been caught')
+  } catch (err: any) {
+    t.ok(err instanceof ConnectionError, `Not a ConnectionError: ${err}`)
+    t.equal(err.message, 'Response aborted while reading the body')
+  }
+
+  server.stop()
+})
+
+test('Connection closed while sending the request body as string (EPIPE)', async t => {
+  t.plan(2)
+
+  let dataCounter = 0
+  function handler (_req: http.IncomingMessage, res: http.ServerResponse) {
+    dataCounter++
+    if (dataCounter === 1) {
+      res.writeHead(413, { 'Connection': 'close' });
+      res.end('Payload Too Large');
+    } else {
+      t.fail('Request should stop trying to send data')
+    }
+  }
+  const [{ port }, server] = await buildServer(handler)
+
+  const connection = new HttpConnection({
+    url: new URL(`http://localhost:${port}`),
+  })
+
+  try {
+    // run one large request where data will be received by socket in multiple chunks
+    await connection.request({
+      path: '/hello',
+      method: 'POST',
+      body: 'x'.repeat(99999999)
+    }, options)
+    t.fail('ConnectionError should have been caught')
+  } catch (err: any) {
+    t.ok(err instanceof ConnectionError, `Not a ConnectionError: ${err}`)
+    t.equal(err.message, 'Response aborted while reading the body')
+  }
+
+  server.stop()
+})
+
 test('Compressed response should return a buffer as body (gzip)', async t => {
   t.plan(2)
 

--- a/test/unit/http-connection.test.ts
+++ b/test/unit/http-connection.test.ts
@@ -1093,7 +1093,9 @@ test('Connection closed while sending the request body as stream (EPIPE)', async
   } catch (err: any) {
     t.ok(err instanceof ConnectionError, `Not a ConnectionError: ${err}`)
     t.ok(
-      err.message === 'Response aborted while reading the body' || err.message.startsWith('write ECONNRESET - Local:'),
+      err.message === 'Response aborted while reading the body' ||
+        err.message.startsWith('write ECONNRESET - Local:') ||
+        err.message.startsWith('read ECONNRESET - Local:'),
       `Unexpected error message: ${err.message}`
     )
   }
@@ -1131,7 +1133,9 @@ test('Connection closed while sending the request body as string (EPIPE)', async
   } catch (err: any) {
     t.ok(err instanceof ConnectionError, `Not a ConnectionError: ${err}`)
     t.ok(
-      err.message === 'Response aborted while reading the body' || err.message.startsWith('write ECONNRESET - Local:'),
+      err.message === 'Response aborted while reading the body' ||
+        err.message.startsWith('write ECONNRESET - Local:') ||
+        err.message.startsWith('read ECONNRESET - Local:'),
       `Unexpected error message: ${err.message}`
     )
   }


### PR DESCRIPTION
There are cases where Elasticsearch may do the following:

1. decide to not read the entire request body
2. return a response with an HTTP error code
3. close the connection

One example of this is, if Elasticsearch receives a `_bulk` request where the `content-length` is larger than it is configured to handle, it will stop reading the request body after the first chunk is sent, respond with a `413 Content Too Large`, and close the request.

In this case, the transport would see this as an `EPIPE` error. The problem is that, when using `HttpConnection` (which many customers still do, as well as Kibana), it would see the response body was finished being sent, via the request `end` event, and stop listening to all events on the request, including `error` events, before the connection was closed by the server and the `EPIPE` error would be raised. So, that unhandled error would bubble up the stack, and the transport would attempt to finish sending the request body over a now-closed connection.

`HttpConnection` was being too optimistic about what signals the end of a request/response cycle. When using the Node.js `http` library, as `HttpConnection` does, the following conditions are a better way to ensure that the cycle has finished:

- request `finish` and response `end` events have both fired (success)
- request `error` event has fired, signaling a connection-related issue (failure)
- response `close` event has fired before either of the above conditions are met, signaling an early connection closure (failure)

This fixes <https://github.com/elastic/elasticsearch-js/issues/2605>.
