### PR TITLE
Reinstate former default for node filter function

### DIFF
--- a/src/connection/BaseConnection.ts
+++ b/src/connection/BaseConnection.ts
@@ -20,6 +20,13 @@ import {
 import { ConfigurationError } from '../errors'
 import { kStatus, kDiagnostic, kCaFingerprint } from '../symbols'
 
+export interface ConnectionRoles {
+  master: boolean
+  data: boolean
+  ingest: boolean
+  ml: boolean
+}
+
 export interface ConnectionOptions {
   url: URL
   tls?: TlsConnectionOptions
@@ -33,6 +40,7 @@ export interface ConnectionOptions {
   proxy?: string | URL
   caFingerprint?: string
   maxEventListeners?: number
+  roles?: ConnectionRoles
 }
 
 export interface ConnectionRequestParams {
@@ -83,6 +91,7 @@ export default class BaseConnection {
   _openRequests: number
   weight: number
   maxEventListeners: number
+  roles?: ConnectionRoles
   [kStatus]: string
   [kCaFingerprint]: string | null
   [kDiagnostic]: Diagnostic
@@ -103,6 +112,7 @@ export default class BaseConnection {
     this.weight = 0
     this._openRequests = 0
     this.maxEventListeners = opts.maxEventListeners ?? 100
+    if (opts.roles != null) this.roles = opts.roles
     this[kStatus] = opts.status ?? BaseConnection.statuses.ALIVE
     this[kDiagnostic] = opts.diagnostic ?? new Diagnostic()
     this[kCaFingerprint] = opts.caFingerprint ?? null

--- a/src/pool/BaseConnectionPool.ts
+++ b/src/pool/BaseConnectionPool.ts
@@ -49,6 +49,19 @@ export interface GetConnectionOptions {
   context: any
 }
 
+export function defaultNodeFilter (conn: Connection): boolean {
+  if (conn.roles != null) {
+    if (
+      // avoid master-only nodes
+      conn.roles.master &&
+      !conn.roles.data &&
+      !conn.roles.ingest &&
+      !conn.roles.ml
+    ) return false
+  }
+  return true
+}
+
 /**
  * Manages the HTTP connections to each Elasticsearch node,
  * keeping track of which are currently dead or alive, and

--- a/src/pool/ClusterConnectionPool.ts
+++ b/src/pool/ClusterConnectionPool.ts
@@ -5,11 +5,13 @@
 
 import BaseConnectionPool, {
   ConnectionPoolOptions,
-  GetConnectionOptions
+  GetConnectionOptions,
+  defaultNodeFilter
 } from './BaseConnectionPool'
 import assert from 'node:assert'
 import Debug from 'debug'
 import { Connection, BaseConnection, ConnectionOptions } from '../connection'
+import { nodeFilterFn } from '../types'
 
 const debug = Debug('elasticsearch')
 
@@ -202,7 +204,7 @@ export default class ClusterConnectionPool extends BaseConnectionPool {
    * @returns {object|null} connection
    */
   getConnection (opts: GetConnectionOptions): Connection | null {
-    const filter = opts.filter != null ? opts.filter : () => true
+    const filter: nodeFilterFn = opts.filter != null ? opts.filter : defaultNodeFilter
     const selector = opts.selector != null ? opts.selector : (c: Connection[]) => c[0]
 
     this.resurrect({

--- a/src/pool/WeightedConnectionPool.ts
+++ b/src/pool/WeightedConnectionPool.ts
@@ -4,12 +4,12 @@
  */
 
 import { Connection, BaseConnection, ConnectionOptions } from '../connection'
+import { nodeFilterFn } from '../types'
 import BaseConnectionPool, {
   ConnectionPoolOptions,
-  GetConnectionOptions
+  GetConnectionOptions,
+  defaultNodeFilter
 } from './BaseConnectionPool'
-
-const noFilter = (): boolean => true
 
 export default class WeightedConnectionPool extends BaseConnectionPool {
   index: number
@@ -36,7 +36,7 @@ export default class WeightedConnectionPool extends BaseConnectionPool {
    * @returns {object|null} connection
    */
   getConnection (opts: GetConnectionOptions): Connection | null {
-    const filter = opts.filter != null ? opts.filter : noFilter
+    const filter: nodeFilterFn = opts.filter != null ? opts.filter : defaultNodeFilter
     // we should be able to find the next node in 1 array scan,
     // if we don't, it means that we are in an infinite loop
     let counter = 0


### PR DESCRIPTION
`roles` connection option was removed during 8.0 refactor

First half of a fix for <https://github.com/elastic/elastic-transport-js/issues/231>
