### PR TITLE
[Backport 8.x] Clean up response 'close' event

### DIFF
--- a/src/connection/HttpConnection.ts
+++ b/src/connection/HttpConnection.ts
@@ -129,7 +129,15 @@ export default class HttpConnection extends BaseConnection {
         )
       }
 
-      const onResponse = (response: http.IncomingMessage): void => {
+      let response: http.IncomingMessage
+
+      const onResponseClose = (): void => {
+        return reject(new ConnectionError('Connection closed while reading the body'))
+      }
+
+      const onResponse = (res: http.IncomingMessage): void => {
+        response = res
+
         cleanListeners()
 
         if (options.asStream === true) {
@@ -197,12 +205,9 @@ export default class HttpConnection extends BaseConnection {
           }
 
           if (requestFinished) {
+            response.removeListener('close', onResponseClose)
             return resolve(connectionRequestResponse)
           }
-        }
-
-        const onResponseClose = (): void => {
-          return reject(new ConnectionError('Response aborted while reading the body'))
         }
 
         if (!isCompressed && !bodyIsBinary) {
@@ -270,6 +275,7 @@ export default class HttpConnection extends BaseConnection {
         requestFinished = true
 
         if (responseEnded) {
+          response?.removeListener('close', onResponseClose)
           if (connectionRequestResponse != null) {
             return resolve(connectionRequestResponse)
           } else {

--- a/test/unit/http-connection.test.ts
+++ b/test/unit/http-connection.test.ts
@@ -690,7 +690,7 @@ test('Bad content length', async t => {
     }, options)
   } catch (err: any) {
     t.ok(err instanceof ConnectionError, `Not a ConnectionError: ${err}`)
-    t.equal(err.message, 'Response aborted while reading the body')
+    t.equal(err.message, 'Connection closed while reading the body')
   }
   server.stop()
 })
@@ -719,7 +719,7 @@ test('Socket destryed while reading the body', async t => {
     }, options)
   } catch (err: any) {
     t.ok(err instanceof ConnectionError, `Not a ConnectionError: ${err}`)
-    t.equal(err.message, 'Response aborted while reading the body')
+    t.equal(err.message, 'Connection closed while reading the body')
   }
   server.stop()
 })
@@ -963,7 +963,8 @@ test('Connection closed while sending the request body as stream (EPIPE)', async
   } catch (err: any) {
     t.ok(err instanceof ConnectionError, `Not a ConnectionError: ${err}`)
     t.ok(
-      err.message === 'Response aborted while reading the body' ||
+      err.message === 'Connection closed while reading the body' ||
+        err.message === 'Response aborted while reading the body' ||
         err.message.startsWith('write ECONNRESET - Local:') ||
         err.message.startsWith('read ECONNRESET - Local:'),
       `Unexpected error message: ${err.message}`
@@ -1003,7 +1004,8 @@ test('Connection closed while sending the request body as string (EPIPE)', async
   } catch (err: any) {
     t.ok(err instanceof ConnectionError, `Not a ConnectionError: ${err}`)
     t.ok(
-      err.message === 'Response aborted while reading the body' ||
+      err.message === 'Connection closed while reading the body' ||
+        err.message === 'Response aborted while reading the body' ||
         err.message.startsWith('write ECONNRESET - Local:') ||
         err.message.startsWith('read ECONNRESET - Local:'),
       `Unexpected error message: ${err.message}`


### PR DESCRIPTION
Backports <https://github.com/elastic/elastic-transport-js/pull/266> to 8.x branch
