### PR TITLE
Use updated OpenTelemetry semantic conventions

### DIFF
--- a/src/Transport.ts
+++ b/src/Transport.ts
@@ -715,6 +715,8 @@ export default class Transport {
       // add path params as otel attributes
       if (params.meta?.pathParts != null) {
         for (const [key, value] of Object.entries(params.meta.pathParts)) {
+          if (value == null) continue
+
           attributes[`db.operation.parameter.${key}`] = value.toString()
 
           if (['index', '_index', 'indices'].includes(key)) {

--- a/test/unit/transport.test.ts
+++ b/test/unit/transport.test.ts
@@ -2508,6 +2508,7 @@ test('OpenTelemetry', t => {
       'url.full': `http://localhost:${port}/`,
       'server.address': 'localhost',
       'server.port': port,
+      'db.response.status_code': "200"
     })
     t.equal(spans[0].status.code, 0)
 
@@ -2542,8 +2543,9 @@ test('OpenTelemetry', t => {
       'url.full': `http://localhost:${port}/`,
       'server.address': 'localhost',
       'server.port': port,
-      'db.elasticsearch.cluster.name': 'foobar',
-      'db.elasticsearch.node.name': 'instance-1',
+      'db.namespace': 'foobar',
+      'elasticsearch.node.name': 'instance-1',
+      'db.response.status_code': '200'
     })
     t.equal(spans[0].status.code, 0)
 


### PR DESCRIPTION
Semantic conventions for Elasticsearch have been updated:

<https://github.com/open-telemetry/semantic-conventions/blob/main/docs/database/elasticsearch.md>

The only missing attribute is still `db.query.text`, as we would ideally have the specification annotate which APIs are sending queries, to avoid false positives. Plus, it would be ideal to scrub any potentially private data from a query before recording it, which would not be possible in a generic way since the client doesn't know the contents or structure of the indices being queried.