### PR TITLE
Add support for providing an agent function to UndiciConnection

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "ms": "^2.1.3",
     "secure-json-parse": "^4.0.0",
     "tslib": "^2.8.1",
-    "undici": "^7.12.0"
+    "undici": "^7.16.0"
   },
   "tap": {
     "files": [

--- a/src/connection/UndiciConnection.ts
+++ b/src/connection/UndiciConnection.ts
@@ -48,68 +48,74 @@ export default class Connection extends BaseConnection {
       throw new ConfigurationError('Undici connection can\'t work with proxies')
     }
 
-    if (typeof opts.agent === 'function' || typeof opts.agent === 'boolean') {
-      throw new ConfigurationError('Undici connection agent options can\'t be a function or a boolean')
+    if (typeof opts.agent === 'boolean') {
+      throw new ConfigurationError('Undici connection agent options can\'t be a boolean')
     }
 
-    if (opts.agent != null && !isUndiciAgentOptions(opts.agent)) {
-      throw new ConfigurationError('Bad agent configuration for Undici agent')
-    }
-
-    const undiciOptions: Pool.Options = {
-      keepAliveTimeout: 600e3,
-      keepAliveMaxTimeout: 600e3,
-      keepAliveTimeoutThreshold: 1000,
-      pipelining: 1,
-      maxHeaderSize: 16384,
-      connections: 256,
-      // only set a timeout if it has a value; default to no timeout
-      // see https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-network.html#_http_client_configuration
-      headersTimeout: this.timeout ?? 0,
-      bodyTimeout: this.timeout ?? 0,
-      ...opts.agent
-    }
-
-    if (this[kCaFingerprint] !== null) {
-      const caFingerprint = this[kCaFingerprint]
-      const connector = buildConnector((this.tls ?? {}) as buildConnector.BuildOptions)
-      undiciOptions.connect = function (opts: buildConnector.Options, cb: buildConnector.Callback) {
-        connector(opts, (err, socket) => {
-          if (err != null) {
-            return cb(err, null)
-          }
-          if (caFingerprint !== null && isTlsSocket(opts, socket)) {
-            const issuerCertificate = getIssuerCertificate(socket)
-            /* istanbul ignore next */
-            if (issuerCertificate == null) {
-              socket.destroy()
-              return cb(new Error('Invalid or malformed certificate'), null)
-            }
-
-            // Certificate will be empty if a session is reused. In this case, getPeerCertificate
-            // will return an empty object, causing a fingeprint check to fail. But, if the session
-            // is being reused, it means this socket's peer certificate fingerprint has already been
-            // checked, so we can skip it and assume the connection is secure.
-            // See https://github.com/nodejs/node/issues/3940#issuecomment-166696776
-            if (Object.keys(issuerCertificate).length === 0 && socket.isSessionReused()) {
-              return cb(null, socket)
-            }
-
-            // Check if fingerprint matches
-            /* istanbul ignore else */
-            if (!isCaFingerprintMatch(caFingerprint, issuerCertificate.fingerprint256)) {
-              socket.destroy()
-              return cb(new Error('Server certificate CA fingerprint does not match the value configured in caFingerprint'), null)
-            }
-          }
-          return cb(null, socket)
-        })
+    // if agent is a function, its returned value must be an Undici object with a `request()` function that works the same as Pool.request()
+    // NOTE: providing an agent function will ignore built-in handling of `caFingerprint` and `tls` options, so they must be handled by the implementer
+    if (typeof opts.agent === 'function') {
+      this.pool = opts.agent(opts)
+    } else {
+      if (opts.agent != null && !isUndiciAgentOptions(opts.agent)) {
+        throw new ConfigurationError('Bad agent configuration for Undici agent')
       }
-    } else if (this.tls !== null) {
-      undiciOptions.connect = this.tls as buildConnector.BuildOptions
-    }
 
-    this.pool = new Pool(this.url.toString(), undiciOptions)
+      const undiciOptions: Pool.Options = {
+        keepAliveTimeout: 600e3,
+        keepAliveMaxTimeout: 600e3,
+        keepAliveTimeoutThreshold: 1000,
+        pipelining: 1,
+        maxHeaderSize: 16384,
+        connections: 256,
+        // only set a timeout if it has a value; default to no timeout
+        // see https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-network.html#_http_client_configuration
+        headersTimeout: this.timeout ?? 0,
+        bodyTimeout: this.timeout ?? 0,
+        ...opts.agent
+      }
+
+      if (this[kCaFingerprint] !== null) {
+        const caFingerprint = this[kCaFingerprint]
+        const connector = buildConnector((this.tls ?? {}) as buildConnector.BuildOptions)
+        undiciOptions.connect = function (opts: buildConnector.Options, cb: buildConnector.Callback) {
+          connector(opts, (err, socket) => {
+            if (err != null) {
+              return cb(err, null)
+            }
+            if (caFingerprint !== null && isTlsSocket(opts, socket)) {
+              const issuerCertificate = getIssuerCertificate(socket)
+              /* istanbul ignore next */
+              if (issuerCertificate == null) {
+                socket.destroy()
+                return cb(new Error('Invalid or malformed certificate'), null)
+              }
+
+              // Certificate will be empty if a session is reused. In this case, getPeerCertificate
+              // will return an empty object, causing a fingeprint check to fail. But, if the session
+              // is being reused, it means this socket's peer certificate fingerprint has already been
+              // checked, so we can skip it and assume the connection is secure.
+              // See https://github.com/nodejs/node/issues/3940#issuecomment-166696776
+              if (Object.keys(issuerCertificate).length === 0 && socket.isSessionReused()) {
+                return cb(null, socket)
+              }
+
+              // Check if fingerprint matches
+              /* istanbul ignore else */
+              if (!isCaFingerprintMatch(caFingerprint, issuerCertificate.fingerprint256)) {
+                socket.destroy()
+                return cb(new Error('Server certificate CA fingerprint does not match the value configured in caFingerprint'), null)
+              }
+            }
+            return cb(null, socket)
+          })
+        }
+      } else if (this.tls !== null) {
+        undiciOptions.connect = this.tls as buildConnector.BuildOptions
+      }
+
+      this.pool = new Pool(this.url.toString(), undiciOptions)
+    }
   }
 
   async request (params: ConnectionRequestParams, options: ConnectionRequestOptions): Promise<ConnectionRequestResponse>
@@ -118,6 +124,7 @@ export default class Connection extends BaseConnection {
     const maxResponseSize = options.maxResponseSize ?? MAX_STRING_LENGTH
     const maxCompressedResponseSize = options.maxCompressedResponseSize ?? MAX_BUFFER_LENGTH
     const requestParams = {
+      origin: this.url,
       method: params.method,
       path: params.path + (params.querystring == null || params.querystring === '' ? '' : `?${params.querystring}`),
       headers: Object.assign({}, this.headers, params.headers),

--- a/test/unit/undici-connection.test.ts
+++ b/test/unit/undici-connection.test.ts
@@ -1259,7 +1259,7 @@ test('limit max open connections using Undici Agent', async t => {
   t.equal(results.filter(r => r.status === 'rejected').length, connections)
   results.filter(r => r.status === 'rejected').forEach(r => {
     t.ok(r.reason instanceof ConnectionError)
-    t.equal(r.reason.message, 'Agent has reached the maximum allowed origins')
+    t.equal(r.reason.message, 'Maximum allowed origins reached')
   })
 
   after.forEach(fn => fn())


### PR DESCRIPTION
Part of https://github.com/elastic/elasticsearch-js/issues/1740, supported by my now-released upstream contribution to Undici https://github.com/nodejs/undici/pull/4365.

Adds support for providing a function to `agent` when using `UndiciConnection`. If a function is provided that returns an [Undici `Agent`](https://undici.nodejs.org/#/docs/api/Agent.md), that agent can be used to enforce open connection limits and other global HTTP options that will apply to an entire `Client` instance.

Documentation and examples will be added to the client repo soon.
