### PR TITLE
track req duration

### DIFF
--- a/src/Transport.ts
+++ b/src/Transport.ts
@@ -499,6 +499,9 @@ export default class Transport {
 
     connectionParams.headers = headers
     while (meta.attempts <= maxRetries) {
+      // Capture start time for request duration tracking
+      const startTime = process.hrtime.bigint()
+
       try {
         if (signal?.aborted) { // eslint-disable-line
           throw new RequestAbortedError('Request has been aborted by the user', result, errorOptions)
@@ -568,6 +571,9 @@ export default class Transport {
 
         if (options.asStream === true) {
           result.body = body
+          // Calculate request duration in milliseconds
+          const endTime = process.hrtime.bigint()
+          meta.duration = Number(endTime - startTime) / 1e6
           this[kDiagnostic].emit('response', null, result)
           return returnMeta ? result : body
         }
@@ -624,10 +630,17 @@ export default class Transport {
           if (isHead && statusCode === 404) {
             result.body = false
           }
+          // Calculate request duration in milliseconds
+          const endTime = process.hrtime.bigint()
+          meta.duration = Number(endTime - startTime) / 1e6
           this[kDiagnostic].emit('response', null, result)
           return returnMeta ? result : result.body
         }
       } catch (error: any) {
+        // Calculate request duration in milliseconds
+        const endTime = process.hrtime.bigint()
+        meta.duration = Number(endTime - startTime) / 1e6
+
         switch (error.name) {
           // should not retry
           case 'ProductNotSupportedError':

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,6 +35,7 @@ export interface DiagnosticResult<TResponse = unknown, TContext = unknown> {
       hosts: any[]
       reason: string
     }
+    duration?: number
   }
 }
 


### PR DESCRIPTION
https://github.com/elastic/elastic-transport-js/issues/35

add client side request duration 
- if we were to track server side duration within client, then we use `event.meta.took`
<!--

Hello there!

Thank you for opening a pull request!
Please remember to always tag the relative issue (if any) and give a brief explanation on what your changes are doing.

If you are patching a security issue, please take a look at https://www.elastic.co/community/security

Finally, please make sure you have signed the Contributor License Agreement
We are not asking you to assign copyright to us, but to give us the right to distribute your code without restriction.
We ask this of all contributors in order to assure our users of the origin and continuing existence of the code. You only need to sign the CLA once.
https://www.elastic.co/contributor-agreement/

Happy coding!

-->
