### PR TITLE
Set up publish workflows for OIDC

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -44,8 +44,6 @@ jobs:
             tag=$(echo "$tag_meta" | cut -d '.' -f1)
             npm publish --provenance --access public --tag "$tag"
           fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Publish version on GitHub
         run: |
           version=$(jq -r .version package.json)


### PR DESCRIPTION
Prep for using [npm trusted publishers](https://docs.npmjs.com/trusted-publishers). See https://github.com/elastic/elasticsearch-js/issues/2996
