### PR TITLE
Drop custom 410 response code handling

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -107,9 +107,7 @@ export class ResponseError extends ElasticsearchClientError {
     Error.captureStackTrace(this, ResponseError)
     this.name = 'ResponseError'
 
-    if (meta.statusCode === 410) {
-      this.message = 'This API is unavailable in the version of Elasticsearch you are using.'
-    } else if (isObject(meta.body) && meta.body.error != null && meta.body.error.type != null) {
+    if (isObject(meta.body) && meta.body.error != null && meta.body.error.type != null) {
       this.message = meta.body.error.type
 
       if (isObject(meta.body.error.caused_by)) {

--- a/test/unit/errors.test.ts
+++ b/test/unit/errors.test.ts
@@ -180,16 +180,3 @@ test('redaction does leak back to original object', t => {
   })
   t.end()
 })
-
-test('410 response uses a custom message', t => {
-  const errResponse = new errors.ResponseError({
-    body: {},
-    statusCode: 410,
-    headers: {},
-    warnings: [],
-    meta: {} as any,
-  });
-
-  t.equal(errResponse.message, 'This API is unavailable in the version of Elasticsearch you are using.')
-  t.end()
-})


### PR DESCRIPTION
Backports https://github.com/elastic/elastic-transport-js/pull/333 to 8.x
