### PR TITLE
Fix exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/transport",
-  "version": "9.3.1",
+  "version": "9.3.2",
   "description": "Transport classes and utilities shared among Node.js Elastic client libraries",
   "type": "commonjs",
   "main": "./index.js",


### PR DESCRIPTION
Ensures export rules work for `@elastic/elasticsearch` both as CommonJS and ESM.
