### PR TITLE
fix: prevent ConnectionError with empty message

### DIFF
--- a/src/Transport.ts
+++ b/src/Transport.ts
@@ -720,9 +720,15 @@ export default class Transport {
             }
 
             // Wrap the error to get a clean stack trace
+            const connectionUrl = meta.connection?.url.toString()
+            const connectionErrorMessage = error.message != null && error.message !== '' && error.message !== 'Connection Error'
+              ? error.message
+              : connectionUrl != null
+                ? `connection failed (${connectionUrl})`
+                : 'connection failed'
             const wrappedError = error.name === 'TimeoutError'
               ? new TimeoutError(error.message, result, errorOptions)
-              : new ConnectionError(error.message, result, errorOptions)
+              : new ConnectionError(connectionErrorMessage, result, errorOptions)
             this[kDiagnostic].emit('response', wrappedError, result)
             throw wrappedError
           }

--- a/test/unit/transport.test.ts
+++ b/test/unit/transport.test.ts
@@ -144,6 +144,48 @@ test('Basic error (ConnectionError)', async t => {
   }
 })
 
+test('Basic error (ConnectionError) with empty message', async t => {
+  t.plan(9)
+
+  for (const message of ['', null, undefined]) {
+    class EmptyMessageConnection extends MockConnection {
+      async request (): Promise<any> {
+        throw new ConnectionError(message as any)
+      }
+    }
+
+    class MyPool extends WeightedConnectionPool {
+      markAlive (connection: Connection): this {
+        t.fail('should not be called')
+        return this
+      }
+
+      markDead (connection: Connection): this {
+        t.pass('called')
+        return this
+      }
+    }
+    const pool = new MyPool({ Connection: EmptyMessageConnection })
+    pool.addConnection('http://localhost:9200')
+
+    const transport = new Transport({
+      connectionPool: pool,
+      maxRetries: 0,
+      retryBackoff: () => 0
+    })
+
+    try {
+      await transport.request({
+        method: 'GET',
+        path: '/hello'
+      }, { meta: true })
+    } catch (err: any) {
+      t.ok(err instanceof ConnectionError)
+      t.equal(err.message, 'connection failed (http://localhost:9200/)')
+    }
+  }
+})
+
 test('Ignore status code', async t => {
   const pool = new WeightedConnectionPool({ Connection: MockConnection })
   pool.addConnection('http://localhost:9200')


### PR DESCRIPTION
fixes https://github.com/elastic/elastic-transport-js/issues/366
