### PR TITLE
ci: add AI backport resolver workflow using Claude via LiteLLM

### DIFF
--- a/.github/workflows/resolve-conflicts.yml
+++ b/.github/workflows/resolve-conflicts.yml
@@ -1,0 +1,251 @@
+name: AI Backport Resolver
+# Triggered when the backport bot posts a failure comment on a PR.
+# Parses the comment, cherry-picks the commit, uses Claude (via LiteLLM) to resolve any
+# conflicts, and opens the backport PR.
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  resolve:
+    name: AI Backport Resolver
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Check comment is a backport failure
+        id: check
+        env:
+          COMMENT_USER: ${{ github.event.comment.user.login }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          if [[ "$COMMENT_USER" != "github-actions[bot]" && \
+                "$COMMENT_USER" != "elastic-vault-github-plugin-prod[bot]" ]]; then
+            echo "should_resolve=false" >> "$GITHUB_OUTPUT"
+            echo "Not a backport bot comment — skipping."
+            exit 0
+          fi
+          if ! echo "$COMMENT_BODY" | grep -q "To backport manually, run these commands"; then
+            echo "should_resolve=false" >> "$GITHUB_OUTPUT"
+            echo "Not a backport failure comment — skipping."
+            exit 0
+          fi
+          echo "should_resolve=true" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout repository
+        if: steps.check.outputs.should_resolve == 'true'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ github.token }}
+
+      - name: Parse comment and attempt cherry-pick
+        if: steps.check.outputs.should_resolve == 'true'
+        id: cherry-pick
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          BASE_BRANCH=$(echo "$COMMENT_BODY" | grep -oP 'git worktree add \.worktrees/\S+ \K\S+')
+          COMMIT_SHA=$(echo "$COMMENT_BODY" | grep -oP 'cherry-pick -x --mainline 1 \K[a-f0-9]+')
+
+          if [[ -z "$BASE_BRANCH" || -z "$COMMIT_SHA" ]]; then
+            echo "ERROR: Could not parse base branch or commit SHA from comment."
+            exit 1
+          fi
+
+          BACKPORT_BRANCH="backport-${PR_NUMBER}-to-${BASE_BRANCH}"
+          PR_TITLE=$(gh pr view "$PR_NUMBER" --json title -q .title)
+
+          echo "base_branch=${BASE_BRANCH}" >> "$GITHUB_OUTPUT"
+          echo "commit_sha=${COMMIT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "backport_branch=${BACKPORT_BRANCH}" >> "$GITHUB_OUTPUT"
+          echo "pr_title=${PR_TITLE}" >> "$GITHUB_OUTPUT"
+
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+
+          git fetch origin "$BASE_BRANCH"
+          git checkout "$BASE_BRANCH"
+          git switch --create "$BACKPORT_BRANCH"
+
+          set +e
+          git cherry-pick -x --mainline 1 "$COMMIT_SHA"
+          CHERRY_EXIT=$?
+          set -e
+
+          if [ $CHERRY_EXIT -eq 0 ]; then
+            echo "conflicts=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "conflicts=true" >> "$GITHUB_OUTPUT"
+            git diff --name-only --diff-filter=U > /tmp/conflicted-files.txt
+            echo "Conflicted files:"
+            cat /tmp/conflicted-files.txt
+          fi
+
+      - name: Resolve conflicts with Claude via LiteLLM
+        if: steps.check.outputs.should_resolve == 'true' && steps.cherry-pick.outputs.conflicts == 'true'
+        id: resolve
+        env:
+          LITELLM_API_KEY: ${{ secrets.LITELLM_API_KEY }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          COMMIT_SHA: ${{ steps.cherry-pick.outputs.commit_sha }}
+          BASE_BRANCH: ${{ steps.cherry-pick.outputs.base_branch }}
+          REPO_SLUG: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          PR_DIFF=$(curl -sL \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github.v3.diff" \
+            "https://api.github.com/repos/${REPO_SLUG}/pulls/${PR_NUMBER}")
+
+          RESOLVED_FILES=()
+          FAILED_FILES=()
+
+          resolve_file() {
+            local filepath="$1"
+            local conflicted_content
+            conflicted_content=$(cat "$filepath")
+
+            local file_diff
+            file_diff=$(echo "${PR_DIFF}" | awk '
+              /^diff --git/ { if (printing) exit; if (index($0, "b/'"${filepath}"'") > 0) printing=1 }
+              printing { print }
+            ' 2>/dev/null || echo "")
+            [ -z "$file_diff" ] && file_diff="(diff not available)"
+
+            local prompt
+            prompt="You are resolving a git merge conflict during a cherry-pick backport.
+
+CONTEXT:
+- PR #${PR_NUMBER} was merged to the main branch.
+- We are backporting commit ${COMMIT_SHA} to \`${BASE_BRANCH}\`.
+- The cherry-pick produced a conflict in this file.
+
+ORIGINAL PR DIFF FOR THIS FILE:
+\`\`\`diff
+${file_diff}
+\`\`\`
+
+FILE WITH CONFLICT MARKERS:
+\`\`\`
+${conflicted_content}
+\`\`\`
+
+INSTRUCTIONS:
+1. The \`<<<<<<< HEAD\` side is the target branch (${BASE_BRANCH}).
+2. The \`=======\` / \`>>>>>>>\` side is the cherry-picked change.
+3. Apply the intent of the cherry-picked change onto the target branch code.
+4. Output ONLY the complete resolved file. No markdown fences, no commentary."
+
+            local response
+            response=$(curl -sf \
+              -H "Authorization: Bearer ${LITELLM_API_KEY}" \
+              -H "Content-Type: application/json" \
+              "https://elastic.litellm-prod.ai/v1/chat/completions" \
+              -d "$(jq -n --arg prompt "$prompt" '{
+                model: "llm-gateway/claude-sonnet-4-6",
+                max_tokens: 16384,
+                messages: [{role: "user", content: $prompt}]
+              }')")
+
+            local resolved
+            resolved=$(echo "$response" | jq -r '.choices[0].message.content // empty')
+
+            if [ -z "$resolved" ]; then
+              echo "  ERROR: Empty response from Claude for ${filepath}"
+              return 1
+            fi
+            if echo "$resolved" | grep -qE '^(<<<<<<<|=======|>>>>>>>)'; then
+              echo "  ERROR: Resolution still contains conflict markers for ${filepath}"
+              return 1
+            fi
+
+            echo "$resolved" > "$filepath"
+            git add "$filepath"
+            echo "  Resolved: ${filepath}"
+          }
+
+          while IFS= read -r filepath; do
+            echo "Resolving: $filepath"
+            if resolve_file "$filepath"; then
+              RESOLVED_FILES+=("$filepath")
+            else
+              FAILED_FILES+=("$filepath")
+            fi
+          done < /tmp/conflicted-files.txt
+
+          echo "Resolved: ${#RESOLVED_FILES[@]} file(s), Failed: ${#FAILED_FILES[@]} file(s)"
+
+          if [ ${#FAILED_FILES[@]} -gt 0 ]; then
+            echo "failed_files=$(IFS=,; echo "${FAILED_FILES[*]}")" >> "$GITHUB_OUTPUT"
+          fi
+
+          resolved_list=""
+          for f in "${RESOLVED_FILES[@]}"; do resolved_list="${resolved_list}- ${f}\n"; done
+          echo "resolved_list<<EOF" >> "$GITHUB_OUTPUT"
+          printf "%b" "$resolved_list" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+          GIT_EDITOR=true git cherry-pick --continue
+
+      - name: Push backport branch and create PR
+        if: steps.check.outputs.should_resolve == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          BASE_BRANCH: ${{ steps.cherry-pick.outputs.base_branch }}
+          BACKPORT_BRANCH: ${{ steps.cherry-pick.outputs.backport_branch }}
+          PR_TITLE: ${{ steps.cherry-pick.outputs.pr_title }}
+          CONFLICTS: ${{ steps.cherry-pick.outputs.conflicts }}
+          RESOLVED_LIST: ${{ steps.resolve.outputs.resolved_list }}
+          FAILED_FILES: ${{ steps.resolve.outputs.failed_files }}
+        run: |
+          set -euo pipefail
+
+          git push --set-upstream origin "$BACKPORT_BRANCH"
+
+          FULL_TITLE="[${BASE_BRANCH}] ${PR_TITLE}"
+
+          if [ "$CONFLICTS" == "false" ]; then
+            PR_BODY="Backport #${PR_NUMBER} to \`${BASE_BRANCH}\` (no conflicts)."
+          else
+            PR_BODY="Backport #${PR_NUMBER} to \`${BASE_BRANCH}\`.
+
+### AI-resolved conflicts
+
+The following files had conflicts resolved automatically by Claude:
+
+${RESOLVED_LIST}"
+            if [ -n "${FAILED_FILES:-}" ]; then
+              PR_BODY="${PR_BODY}
+
+> ⚠️ The following files could not be resolved automatically and still contain conflict markers: \`${FAILED_FILES}\`"
+            else
+              PR_BODY="${PR_BODY}
+> **Please review the AI-resolved conflicts carefully before merging.**"
+            fi
+          fi
+
+          BACKPORT_PR_URL=$(gh pr create \
+            --base "$BASE_BRANCH" \
+            --title "$FULL_TITLE" \
+            --body "$PR_BODY")
+
+          if [ "$CONFLICTS" == "false" ]; then
+            COMMENT="**AI Backport Resolver** created a backport PR (no conflicts): ${BACKPORT_PR_URL}"
+          else
+            COMMENT="**AI Backport Resolver** resolved conflicts and created a backport PR: ${BACKPORT_PR_URL}
+
+Files with AI-resolved conflicts:
+${RESOLVED_LIST}"
+          fi
+
+          gh pr comment "$PR_NUMBER" --body "$COMMENT"


### PR DESCRIPTION
Adds the full self-contained AI backport resolver workflow. When the backport bot posts a failure comment, this automatically cherry-picks, resolves conflicts with Claude (`llm-gateway/claude-sonnet-4-6` via `elastic.litellm-prod.ai`), and opens the backport PR. Requires `LITELLM_API_KEY` secret. Reference: [elastic/dev-experience-team#1067](https://github.com/elastic/dev-experience-team/pull/1067).