### PR TITLE
Strip credentials from OTel span attribute

### DIFF
--- a/src/Transport.ts
+++ b/src/Transport.ts
@@ -21,7 +21,7 @@ import {
   ErrorOptions
 } from './errors'
 import { Connection, ConnectionRequestParams } from './connection'
-import { isBinary } from './connection/BaseConnection'
+import { isBinary, stripAuth } from './connection/BaseConnection'
 import Diagnostic from './Diagnostic'
 import Serializer from './Serializer'
 import { Readable as ReadableStream } from 'node:stream'
@@ -525,7 +525,7 @@ export default class Transport {
         // generate required OpenTelemetry attributes from the request URL
         const requestUrl = meta.connection.url
         otelSpan?.setAttributes({
-          'url.full': requestUrl.toString(),
+          'url.full': stripAuth(requestUrl.toString()),
           'server.address': requestUrl.hostname
         })
         if (requestUrl.port === '') {

--- a/src/connection/BaseConnection.ts
+++ b/src/connection/BaseConnection.ts
@@ -185,7 +185,7 @@ const validStatuses = Object.keys(BaseConnection.statuses)
   // @ts-expect-error
   .map(k => BaseConnection.statuses[k])
 
-function stripAuth (url: string): string {
+export function stripAuth (url: string): string {
   if (!url.includes('@')) return url
   return url.slice(0, url.indexOf('//') + 2) + url.slice(url.indexOf('@') + 1)
 }

--- a/test/unit/transport.test.ts
+++ b/test/unit/transport.test.ts
@@ -2701,6 +2701,40 @@ test('OpenTelemetry', t => {
     server.stop()
   })
 
+  t.test('strip auth from url.full attribute', async t => {
+    t.plan(2)
+
+    function handler (req: http.IncomingMessage, res: http.ServerResponse) {
+      res.end('ok')
+    }
+
+    const [{ port }, server] = await buildServer(handler)
+    const pool = new WeightedConnectionPool({ Connection: UndiciConnection })
+    pool.addConnection(`http://user:pass@localhost:${port}`)
+    const transport = new Transport({ connectionPool: pool })
+
+    await transport.request({
+      path: '/hello',
+      method: 'GET',
+      meta: { name: 'hello' },
+    })
+
+    const spans = exporter.getFinishedSpans()
+
+    t.same(spans[0].attributes, {
+      'db.system': 'elasticsearch',
+      'http.request.method': 'GET',
+      'db.operation.name': 'hello',
+      'url.full': `http://localhost:${port}/`,
+      'server.address': 'localhost',
+      'server.port': port,
+      'db.response.status_code': "200"
+    })
+    t.equal(spans[0].status.code, 0)
+
+    server.stop()
+  })
+
   t.test('cloud cluster and instance details', async t => {
     t.plan(2)
 


### PR DESCRIPTION
# Overview

The Elasticsearch JS client adds the server's URL to the OpenTelemetry `url.full` span attribute.
In case the URL contains credentials, it keeps them. This is bad practice, as [noted](https://opentelemetry.io/docs/specs/semconv/registry/attributes/url/#url-attributes) in the official OpenTelemetry specs for `url.full`.


This PR strips the credentials before setting the span attributes.