### PR TITLE
fix: mark timed-out nodes dead when retryOnTimeout is false

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/transport",
-  "version": "9.3.6",
+  "version": "9.3.7",
   "description": "Transport classes and utilities shared among Node.js Elastic client libraries",
   "type": "commonjs",
   "main": "./index.js",

--- a/src/Transport.ts
+++ b/src/Transport.ts
@@ -681,6 +681,9 @@ export default class Transport {
           // @ts-expect-error `case` fallthrough is intentional: should retry if retryOnTimeout is true
           case 'TimeoutError':
             if (!this[kRetryOnTimeout]) {
+              // mark dead before early throw: when not retrying, we never reach the
+              // ConnectionError fallthrough that would otherwise call markDead
+              this[kConnectionPool].markDead(meta.connection as Connection)
               const wrappedError = new TimeoutError(error.message, result, { ...errorOptions, cause: error })
               this[kDiagnostic].emit('response', wrappedError, result)
               throw wrappedError

--- a/test/unit/transport.test.ts
+++ b/test/unit/transport.test.ts
@@ -111,6 +111,40 @@ test('Basic error (TimeoutError)', async t => {
   }
 })
 
+test('TimeoutError marks connection dead even when retryOnTimeout is false', async t => {
+  t.plan(2)
+
+  class MyPool extends WeightedConnectionPool {
+    markAlive (connection: Connection): this {
+      t.fail('should not be called')
+      return this
+    }
+
+    markDead (connection: Connection): this {
+      t.pass('called')
+      return this
+    }
+  }
+  const pool = new MyPool({ Connection: MockConnectionTimeout })
+  pool.addConnection('http://localhost:9200')
+
+  const transport = new Transport({
+    connectionPool: pool,
+    maxRetries: 0,
+    retryOnTimeout: false,
+    retryBackoff: () => 0,
+  })
+
+  try {
+    await transport.request({
+      method: 'GET',
+      path: '/hello'
+    })
+  } catch (err: any) {
+    t.ok(err instanceof TimeoutError)
+  }
+})
+
 test('Basic error (ConnectionError)', async t => {
   t.plan(2)
 


### PR DESCRIPTION
Timed-out nodes are not properly marked as dead/unhealthy if the `retryOnTimeout` option is set to `false`.
