### PR TITLE
feat: capture sanitized search queries as db.query.text

### DIFF
--- a/src/Transport.ts
+++ b/src/Transport.ts
@@ -293,6 +293,11 @@ export default class Transport {
       suppressInternalInstrumentation: false
     }, opts.openTelemetry ?? {})
 
+    // Runtime kill switch so ops can disable query capture without redeploying.
+    if (process.env.OTEL_ELASTICSEARCH_CAPTURE_SEARCH_QUERY?.toLowerCase() === 'false') {
+      otelOptions.captureSearchQuery = false
+    }
+
     // Middleware are always registered and self-gate on their own options, so
     // enablement (and rollback) stays driven by client config rather than which
     // middleware is registered.

--- a/src/middleware/OpenTelemetry.ts
+++ b/src/middleware/OpenTelemetry.ts
@@ -8,7 +8,24 @@ import { suppressTracing } from '@opentelemetry/core'
 import { Middleware, MiddlewareContext, MiddlewareName, MiddlewareNext, MiddlewarePriority } from './types'
 import { TransportResult } from '../types'
 import { stripAuth } from '../connection/BaseConnection'
+import { sanitizeJsonBody, sanitizeNdjsonBody, sanitizeStringQuery } from '../security'
+import Serializer from '../Serializer'
 import { transportVersion } from '../version.generated'
+
+/** Endpoints whose body can be captured as `db.query.text`. */
+export const SEARCH_LIKE_ENDPOINTS: ReadonlySet<string> = new Set([
+  'async_search.submit', 'esql.async_query', 'esql.query', 'fleet.msearch', 'fleet.search',
+  'knn_search', 'msearch', 'rollup.rollup_search', 'search', 'search_mvt', 'sql.query'
+])
+
+/** Endpoints whose body is an ES|QL/SQL string query (captured only when parameterized). */
+export const STRING_QUERY_ENDPOINTS: ReadonlySet<string> = new Set(['esql.async_query', 'esql.query', 'sql.query'])
+
+/** Endpoints whose body is NDJSON (header + query line pairs). */
+export const NDJSON_ENDPOINTS: ReadonlySet<string> = new Set(['fleet.msearch', 'msearch'])
+
+/** Max length of the `db.query.text` attribute, in characters. */
+export const SEARCH_QUERY_MAX_LENGTH = 2048
 
 export interface OpenTelemetryOptions {
   enabled?: boolean
@@ -18,6 +35,16 @@ export interface OpenTelemetryOptions {
    * HTTP (e.g. undici) instrumentation is suppressed too.
    */
   suppressInternalInstrumentation?: boolean
+  /**
+   * Records sanitized request bodies as `db.query.text`. Off by default: even
+   * sanitized, query structure can reveal schema or search patterns, so enable only
+   * where tracing data is access-controlled.
+   */
+  captureSearchQuery?: boolean
+}
+
+function isStream (body: unknown): boolean {
+  return body != null && typeof (body as any).pipe === 'function'
 }
 
 export class OpenTelemetryMiddleware implements Middleware {
@@ -26,10 +53,12 @@ export class OpenTelemetryMiddleware implements Middleware {
 
   private readonly tracer: Tracer
   private readonly transportOptions: OpenTelemetryOptions
+  private readonly serializer: Serializer
 
   constructor (transportOptions: OpenTelemetryOptions) {
     this.tracer = opentelemetry.trace.getTracer('@elastic/transport', transportVersion)
     this.transportOptions = transportOptions
+    this.serializer = new Serializer()
   }
 
   around = async (ctx: MiddlewareContext, next: MiddlewareNext): Promise<TransportResult> => {
@@ -44,7 +73,7 @@ export class OpenTelemetryMiddleware implements Middleware {
       otelContext = suppressTracing(otelContext)
     }
 
-    const attributes = this.buildAttributes(ctx)
+    const attributes = this.buildAttributes(ctx, otelOptions)
     // startActiveSpan makes the span the active context for the duration of `next()`,
     // so spans created by the HTTP layer nest under this Elasticsearch span.
     return await this.tracer.startActiveSpan(
@@ -99,7 +128,7 @@ export class OpenTelemetryMiddleware implements Middleware {
     }
   }
 
-  private buildAttributes (ctx: MiddlewareContext): Attributes {
+  private buildAttributes (ctx: MiddlewareContext, otelOptions: OpenTelemetryOptions): Attributes {
     const { params } = ctx
     const attributes: Attributes = {
       'db.system': 'elasticsearch',
@@ -131,6 +160,39 @@ export class OpenTelemetryMiddleware implements Middleware {
       }
     }
 
+    if ((otelOptions.captureSearchQuery ?? false) && params.meta?.name != null && SEARCH_LIKE_ENDPOINTS.has(params.meta.name)) {
+      const queryText = this.captureQueryText(params.meta.name, ctx)
+      if (queryText != null) attributes['db.query.text'] = queryText
+    }
+
     return attributes
+  }
+
+  private captureQueryText (name: string, ctx: MiddlewareContext): string | null {
+    const { params } = ctx
+    const rawBody = NDJSON_ENDPOINTS.has(name) ? params.bulkBody : params.body
+    if (rawBody == null || rawBody === '' || isStream(rawBody)) return null
+
+    let bodyStr: string
+    if (typeof rawBody === 'string') {
+      bodyStr = rawBody
+    } else if (Array.isArray(rawBody)) {
+      bodyStr = this.serializer.ndserialize(rawBody)
+    } else {
+      bodyStr = this.serializer.serialize(rawBody)
+    }
+
+    let sanitized: string | null
+    if (NDJSON_ENDPOINTS.has(name)) {
+      sanitized = sanitizeNdjsonBody(bodyStr)
+    } else if (STRING_QUERY_ENDPOINTS.has(name)) {
+      sanitized = sanitizeStringQuery(bodyStr)
+    } else {
+      sanitized = sanitizeJsonBody(bodyStr)
+    }
+
+    if (sanitized == null) return null
+    // Sanitize first, then truncate, so no raw literal can survive near the cutoff.
+    return sanitized.slice(0, SEARCH_QUERY_MAX_LENGTH)
   }
 }

--- a/src/security.ts
+++ b/src/security.ts
@@ -84,3 +84,71 @@ export function redactDiagnostic (diag: DiagnosticResult, options: RedactionOpti
 
   return diag
 }
+
+/** Serializes a value, keeping object keys but replacing literals: strings -> `"?"`, others -> `?`. */
+function sanitizeValue (val: unknown): string {
+  if (val === null || typeof val === 'number' || typeof val === 'boolean') return '?'
+  if (typeof val === 'string') return '"?"'
+  if (Array.isArray(val)) return '[' + val.map(sanitizeValue).join(',') + ']'
+  if (typeof val === 'object') {
+    const entries = Object.entries(val as Record<string, unknown>)
+    return '{' + entries.map(([k, v]) => JSON.stringify(k) + ':' + sanitizeValue(v)).join(',') + '}'
+  }
+  return '?'
+}
+
+/** Replaces literal values in a JSON body with placeholders, keeping keys. Null on empty/invalid input; never throws. */
+export function sanitizeJsonBody (body: string | null | undefined): string | null {
+  if (body == null || body === '') return null
+  try {
+    return sanitizeValue(JSON.parse(body))
+  } catch {
+    return null
+  }
+}
+
+/** Extracts an ES|QL/SQL `query` field, but only when parameterized (contains `?`). Null otherwise; never throws. */
+export function sanitizeStringQuery (body: string | null | undefined): string | null {
+  if (body == null || body === '') return null
+  try {
+    const parsed: unknown = JSON.parse(body)
+    if (parsed == null || typeof parsed !== 'object' || Array.isArray(parsed)) return null
+    const query = (parsed as Record<string, unknown>).query
+    if (typeof query !== 'string') return null
+    if (!query.includes('?')) return null
+    return query
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Sanitizes an msearch NDJSON body: even lines are headers (verbatim), odd lines are
+ * query bodies (run through sanitizeJsonBody). Preserves EOL style and trailing newline.
+ * Null on empty input or if any query line fails to sanitize; never throws.
+ */
+export function sanitizeNdjsonBody (body: string | null | undefined): string | null {
+  if (body == null || body === '') return null
+  try {
+    const eol = body.includes('\r\n') ? '\r\n' : '\n'
+    const hasTrailingNewline = body.endsWith('\n')
+    let lines = body.split(eol)
+    if (hasTrailingNewline && lines[lines.length - 1] === '') {
+      lines = lines.slice(0, -1)
+    }
+    const processed: string[] = []
+    for (let i = 0; i < lines.length; i++) {
+      if (i % 2 === 0) {
+        processed.push(lines[i])
+      } else {
+        const sanitized = sanitizeJsonBody(lines[i])
+        if (sanitized === null) return null
+        processed.push(sanitized)
+      }
+    }
+    const joined = processed.join(eol)
+    return hasTrailingNewline ? joined + eol : joined
+  } catch {
+    return null
+  }
+}

--- a/test/unit/middleware/opentelemetry.test.ts
+++ b/test/unit/middleware/opentelemetry.test.ts
@@ -218,4 +218,80 @@ test('OpenTelemetryMiddleware', async t => {
     await runOk(mw, createContext())
     t.equal(exporter.getFinishedSpans().length, 0)
   })
+
+  async function captureQuerySpan (params: Partial<TransportRequestParams>, options: any = {}, transportOptions: any = { enabled: true, captureSearchQuery: true }): Promise<any> {
+    const mw = new OpenTelemetryMiddleware(transportOptions)
+    await runOk(mw, createContext(params, options))
+    const spans = exporter.getFinishedSpans()
+    return spans[spans.length - 1]
+  }
+
+  await t.test('captures sanitized db.query.text for a DSL search body', async t => {
+    const span = await captureQuerySpan({ method: 'POST', meta: { name: 'search' }, body: { query: { match: { title: 'elasticsearch' } } } })
+    t.equal(span.attributes['db.query.text'], '{"query":{"match":{"title":"?"}}}')
+  })
+
+  await t.test('captures sanitized db.query.text from an NDJSON bulkBody', async t => {
+    const span = await captureQuerySpan({
+      method: 'POST',
+      meta: { name: 'msearch' },
+      bulkBody: [{ index: 'my-index' }, { query: { match_all: {} } }]
+    })
+    t.equal(span.attributes['db.query.text'], '{"index":"my-index"}\n{"query":{"match_all":{}}}\n')
+  })
+
+  await t.test('captures db.query.text for parameterized string-query endpoints', async t => {
+    const span = await captureQuerySpan({ method: 'POST', meta: { name: 'esql.query' }, body: { query: 'FROM logs | WHERE host == ?' } })
+    t.equal(span.attributes['db.query.text'], 'FROM logs | WHERE host == ?')
+  })
+
+  await t.test('omits db.query.text for non-parameterized string queries', async t => {
+    const span = await captureQuerySpan({ method: 'POST', meta: { name: 'esql.query' }, body: { query: 'FROM logs | WHERE host == "a"' } })
+    t.equal(span.attributes['db.query.text'], undefined)
+  })
+
+  await t.test('omits db.query.text for empty, null and stream bodies', async t => {
+    t.equal((await captureQuerySpan({ method: 'POST', meta: { name: 'search' }, body: '' })).attributes['db.query.text'], undefined, 'empty string')
+    t.equal((await captureQuerySpan({ method: 'POST', meta: { name: 'search' } })).attributes['db.query.text'], undefined, 'no body')
+    t.equal((await captureQuerySpan({ method: 'POST', meta: { name: 'search' }, body: { pipe () {} } as any })).attributes['db.query.text'], undefined, 'stream body')
+  })
+
+  await t.test('omits db.query.text for non-search endpoints', async t => {
+    const span = await captureQuerySpan({ method: 'PUT', meta: { name: 'index' }, body: { title: 'doc' } })
+    t.equal(span.attributes['db.query.text'], undefined)
+  })
+
+  await t.test('omits db.query.text when captureSearchQuery is not configured', async t => {
+    const span = await captureQuerySpan({ method: 'POST', meta: { name: 'search' }, body: { query: { match_all: {} } } }, {}, { enabled: true })
+    t.equal(span.attributes['db.query.text'], undefined)
+  })
+
+  await t.test('omits db.query.text when captureSearchQuery is false', async t => {
+    const span = await captureQuerySpan({ method: 'POST', meta: { name: 'search' }, body: { query: { match_all: {} } } }, {}, { enabled: true, captureSearchQuery: false })
+    t.equal(span.attributes['db.query.text'], undefined)
+  })
+
+  await t.test('per-request captureSearchQuery: false suppresses capture', async t => {
+    const span = await captureQuerySpan(
+      { method: 'POST', meta: { name: 'search' }, body: { query: { match_all: {} } } },
+      { openTelemetry: { captureSearchQuery: false } }
+    )
+    t.equal(span.attributes['db.query.text'], undefined)
+  })
+
+  await t.test('per-request captureSearchQuery: true enables capture when transport default is false', async t => {
+    const span = await captureQuerySpan(
+      { method: 'POST', meta: { name: 'search' }, body: { query: { match_all: {} } } },
+      { openTelemetry: { captureSearchQuery: true } },
+      { enabled: true, captureSearchQuery: false }
+    )
+    t.equal(span.attributes['db.query.text'], '{"query":{"match_all":{}}}')
+  })
+
+  await t.test('truncates db.query.text to the maximum length', async t => {
+    const body: Record<string, string> = {}
+    for (let i = 0; i < 400; i++) body[`k${i}`] = `v${i}`
+    const span = await captureQuerySpan({ method: 'POST', meta: { name: 'search' }, body })
+    t.equal((span.attributes['db.query.text'] as string).length, 2048)
+  })
 })

--- a/test/unit/security.test.ts
+++ b/test/unit/security.test.ts
@@ -5,7 +5,7 @@
 
 import { test } from 'tap'
 import { inspect} from 'util'
-import { redactObject } from '../../src/security'
+import { redactObject, sanitizeJsonBody, sanitizeNdjsonBody, sanitizeStringQuery } from '../../src/security'
 
 test('redactObject', t => {
   t.test('redacts values for matching keys at 8+ levels of nesting', t => {
@@ -198,6 +198,78 @@ test('redactObject', t => {
     t.doesNotThrow(() => redactObject(undefined))
     t.doesNotThrow(() => redactObject({ foo: undefined }))
     t.doesNotThrow(() => redactObject({ foo: null }))
+    t.end()
+  })
+
+  t.end()
+})
+
+test('sanitizeJsonBody', t => {
+  t.test('preserves keys and replaces string, number, boolean and null values with placeholders', t => {
+    const out = sanitizeJsonBody('{"query":{"term":{"user":"kimchy","age":30,"active":true,"deleted":null}}}')
+    t.equal(out, '{"query":{"term":{"user":"?","age":?,"active":?,"deleted":?}}}')
+    t.end()
+  })
+
+  t.test('does not leak string values containing escaped quotes', t => {
+    const out = sanitizeJsonBody('{"q":"he said \\"hi\\""}')
+    t.equal(out, '{"q":"?"}')
+    t.end()
+  })
+
+  t.test('returns null for null, undefined and empty string', t => {
+    t.equal(sanitizeJsonBody(null), null)
+    t.equal(sanitizeJsonBody(undefined), null)
+    t.equal(sanitizeJsonBody(''), null)
+    t.end()
+  })
+
+  t.end()
+})
+
+test('sanitizeStringQuery', t => {
+  t.test('returns the query string when parameterized', t => {
+    const out = sanitizeStringQuery('{"query":"FROM logs | WHERE host == ?"}')
+    t.equal(out, 'FROM logs | WHERE host == ?')
+    t.end()
+  })
+
+  t.test('returns null when the query is not parameterized', t => {
+    t.equal(sanitizeStringQuery('{"query":"FROM logs | WHERE host == \\"a\\""}'), null)
+    t.end()
+  })
+
+  t.test('returns null for missing/non-string query, non-object bodies and bad JSON', t => {
+    t.equal(sanitizeStringQuery('{"foo":"bar"}'), null)
+    t.equal(sanitizeStringQuery('{"query":123}'), null)
+    t.equal(sanitizeStringQuery('["a","b"]'), null)
+    t.equal(sanitizeStringQuery('not json'), null)
+    t.equal(sanitizeStringQuery(''), null)
+    t.end()
+  })
+
+  t.end()
+})
+
+test('sanitizeNdjsonBody', t => {
+  t.test('passes header lines verbatim and sanitizes query lines', t => {
+    const body = '{"index":"my-index"}\n{"query":{"match":{"title":"elasticsearch"}}}\n'
+    const out = sanitizeNdjsonBody(body)
+    t.equal(out, '{"index":"my-index"}\n{"query":{"match":{"title":"?"}}}\n')
+    t.end()
+  })
+
+  t.test('preserves CRLF line endings and trailing newline', t => {
+    const body = '{"index":"my-index"}\r\n{"query":{"match_all":{}}}\r\n'
+    const out = sanitizeNdjsonBody(body)
+    t.equal(out, '{"index":"my-index"}\r\n{"query":{"match_all":{}}}\r\n')
+    t.end()
+  })
+
+  t.test('returns null for null, undefined and empty string', t => {
+    t.equal(sanitizeNdjsonBody(null), null)
+    t.equal(sanitizeNdjsonBody(undefined), null)
+    t.equal(sanitizeNdjsonBody(''), null)
     t.end()
   })
 


### PR DESCRIPTION
extends #383. adds `db.query.text` capture on top of the otel middleware.

opt-in via `captureSearchQuery`, default off since query contents are sensitive even after sanitizing. when on, sanitized request bodies for search-like endpoints (search, msearch, esql.query, sql.query, knn_search, etc) get recorded as `db.query.text`:
- json bodies: string/number/bool/null literals swapped for placeholders
- msearch ndjson: query lines sanitized, header lines kept as-is
- esql/sql string queries: only captured when parameterized (contains `?`)

sanitize the full body first, then truncate to 2048 chars so no raw literal can sneak in near the cutoff. `OTEL_ELASTICSEARCH_CAPTURE_SEARCH_QUERY=false` disables it at runtime, and per-request `openTelemetry.captureSearchQuery` overrides the default.

related to elastic/elasticsearch-js#3107