### PR TITLE
fix: add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -6,6 +6,10 @@ on:
       - closed
       - labeled
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   backport:
     name: Backport


### PR DESCRIPTION
## Summary

- Adds explicit `permissions:` block to `.github/workflows/backport.yml`
- Grants the permissions required for the backport workflow to operate

## Motivation

InfoSec is changing GITHUB_TOKEN default permissions from read/write to read-only on July 15th. This PR adds explicit permissions blocks to all workflows that require write access before that change takes effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)