### PR TITLE
fix: support path prefix in node URL

### DIFF
--- a/src/connection/UndiciConnection.ts
+++ b/src/connection/UndiciConnection.ts
@@ -114,7 +114,7 @@ export default class Connection extends BaseConnection {
         undiciOptions.connect = this.tls as buildConnector.BuildOptions
       }
 
-      this.pool = new Pool(this.url.toString(), undiciOptions)
+      this.pool = new Pool(this.url.origin, undiciOptions)
     }
   }
 
@@ -123,10 +123,11 @@ export default class Connection extends BaseConnection {
   async request (params: ConnectionRequestParams, options: any): Promise<any> {
     const maxResponseSize = options.maxResponseSize ?? MAX_STRING_LENGTH
     const maxCompressedResponseSize = options.maxCompressedResponseSize ?? MAX_BUFFER_LENGTH
+    const pathPrefix = this.url.pathname === '/' ? '' : this.url.pathname.replace(/\/$/, '')
     const requestParams = {
       origin: this.url,
       method: params.method,
-      path: params.path + (params.querystring == null || params.querystring === '' ? '' : `?${params.querystring}`),
+      path: pathPrefix + params.path + (params.querystring == null || params.querystring === '' ? '' : `?${params.querystring}`),
       headers: Object.assign({}, this.headers, params.headers),
       body: params.body,
       signal: options.signal ?? new AbortController().signal

--- a/test/unit/undici-connection.test.ts
+++ b/test/unit/undici-connection.test.ts
@@ -306,6 +306,26 @@ test('Should concatenate the querystring', async t => {
   server.stop()
 })
 
+test('Node URL with path prefix', async t => {
+  t.plan(1)
+
+  function handler (req: http.IncomingMessage, res: http.ServerResponse) {
+    t.equal(req.url, '/elastic/_search')
+    res.end('ok')
+  }
+
+  const [{ port }, server] = await buildServer(handler)
+  const connection = new UndiciConnection({
+    url: new URL(`http://localhost:${port}/elastic/`)
+  })
+
+  await connection.request({
+    path: '/_search',
+    method: 'GET'
+  }, options)
+  server.stop()
+})
+
 test('Body request', async t => {
   t.plan(1)
 


### PR DESCRIPTION
Fixes elastic/elasticsearch-js#3342 (and the chain of duplicates going back to 2015: #239, #1709, #1625, #2296).

`UndiciConnection` was passing the full node URL to `new Pool()`, but undici only accepts an origin (`scheme://host:port`). Any path component causes an `invalid url` error at connection setup.

**Changes:**
- Use `this.url.origin` when creating the undici `Pool`, so paths are accepted
- Prepend `this.url.pathname` (minus trailing slash) to every request path

`HttpConnection` already handles this correctly via its `resolve()` helper - no change needed there.

The previous workaround (custom `Transport` subclass) still works but required owning the `Client` instantiation. This fixes it at the layer where it belongs, including for transitive dependency consumers.