### PR TITLE
[8.x] fix: support path prefix in node URL

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [18.x, 20.x, 22.x]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
@@ -31,6 +31,11 @@ jobs:
       - name: Install
         run: |
           npm install
+
+      - name: Enable WebCrypto global for Node 18
+        if: matrix.node-version == '18.x'
+        shell: bash
+        run: echo "NODE_OPTIONS=--experimental-global-webcrypto" >> $GITHUB_ENV
 
       - name: Lint
         run: |
@@ -51,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [20.x, 22.x]
+        node-version: [18.x, 20.x, 22.x]
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -86,6 +91,11 @@ jobs:
           cd "$GITHUB_WORKSPACE/client"
           npm install
           npm install ../transport --install-links
+
+      - name: Enable WebCrypto global for Node 18
+        if: matrix.node-version == '18.x'
+        shell: bash
+        run: echo "NODE_OPTIONS=--experimental-global-webcrypto" >> $GITHUB_ENV
 
       - name: Unit test
         run: |

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -32,20 +32,19 @@ jobs:
         run: |
           npm install
 
-      - name: Enable WebCrypto global for Node 18
-        if: matrix.node-version == '18.x'
-        shell: bash
-        run: echo "NODE_OPTIONS=--experimental-global-webcrypto" >> $GITHUB_ENV
-
       - name: Lint
         run: |
           npm run lint
 
       - name: Unit test
+        env:
+          NODE_OPTIONS: ${{ matrix.node-version == '18.x' && '--experimental-global-webcrypto' || '' }}
         run: |
           npm run test:unit
 
       - name: Acceptance test
+        env:
+          NODE_OPTIONS: ${{ matrix.node-version == '18.x' && '--experimental-global-webcrypto' || '' }}
         run: |
           npm run test:acceptance
 
@@ -92,12 +91,9 @@ jobs:
           npm install
           npm install ../transport --install-links
 
-      - name: Enable WebCrypto global for Node 18
-        if: matrix.node-version == '18.x'
-        shell: bash
-        run: echo "NODE_OPTIONS=--experimental-global-webcrypto" >> $GITHUB_ENV
-
       - name: Unit test
+        env:
+          NODE_OPTIONS: ${{ matrix.node-version == '18.x' && '--experimental-global-webcrypto' || '' }}
         run: |
           cd "$GITHUB_WORKSPACE/client"
           npm run test:unit

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [20.x, 22.x]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
@@ -51,7 +51,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [20.x, 22.x]
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "proxy": "2.2.0",
     "rimraf": "6.0.1",
     "stoppable": "1.1.0",
-    "tap": "21.0.1",
+    "tap": "^20.0.3",
     "ts-node": "10.9.2",
     "ts-standard": "12.0.2",
     "typescript": "5.7.3",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   "devDependencies": {
     "@opentelemetry/sdk-trace-base": "1.30.1",
     "@sinonjs/fake-timers": "14.0.0",
-    "@tapjs/clock": "^2.0.3",
+    "@tapjs/clock": "3.0.0",
     "@types/debug": "4.1.12",
     "@types/ms": "0.7.34",
     "@types/node": "22.10.7",
@@ -88,7 +88,7 @@
     "proxy": "2.2.0",
     "rimraf": "6.0.1",
     "stoppable": "1.1.0",
-    "tap": "^20.0.3",
+    "tap": "21.0.1",
     "ts-node": "10.9.2",
     "ts-standard": "12.0.2",
     "typescript": "5.7.3",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   "devDependencies": {
     "@opentelemetry/sdk-trace-base": "1.30.1",
     "@sinonjs/fake-timers": "14.0.0",
-    "@tapjs/clock": "3.0.0",
+    "@tapjs/clock": "^2.0.3",
     "@types/debug": "4.1.12",
     "@types/ms": "0.7.34",
     "@types/node": "22.10.7",

--- a/src/connection/UndiciConnection.ts
+++ b/src/connection/UndiciConnection.ts
@@ -107,7 +107,7 @@ export default class Connection extends BaseConnection {
       undiciOptions.connect = this.tls as buildConnector.BuildOptions
     }
 
-    this.pool = new Pool(this.url.toString(), undiciOptions)
+    this.pool = new Pool(this.url.origin, undiciOptions)
   }
 
   async request (params: ConnectionRequestParams, options: ConnectionRequestOptions): Promise<ConnectionRequestResponse>
@@ -115,9 +115,10 @@ export default class Connection extends BaseConnection {
   async request (params: ConnectionRequestParams, options: any): Promise<any> {
     const maxResponseSize = options.maxResponseSize ?? MAX_STRING_LENGTH
     const maxCompressedResponseSize = options.maxCompressedResponseSize ?? MAX_BUFFER_LENGTH
+    const pathPrefix = this.url.pathname === '/' ? '' : this.url.pathname.replace(/\/$/, '')
     const requestParams = {
       method: params.method,
-      path: params.path + (params.querystring == null || params.querystring === '' ? '' : `?${params.querystring}`),
+      path: pathPrefix + params.path + (params.querystring == null || params.querystring === '' ? '' : `?${params.querystring}`),
       headers: Object.assign({}, this.headers, params.headers),
       body: params.body,
       signal: options.signal ?? new AbortController().signal

--- a/test/unit/undici-connection.test.ts
+++ b/test/unit/undici-connection.test.ts
@@ -270,6 +270,26 @@ test('Should concatenate the querystring', async t => {
   server.stop()
 })
 
+test('Node URL with path prefix', async t => {
+  t.plan(1)
+
+  function handler (req: http.IncomingMessage, res: http.ServerResponse) {
+    t.equal(req.url, '/elastic/_search')
+    res.end('ok')
+  }
+
+  const [{ port }, server] = await buildServer(handler)
+  const connection = new UndiciConnection({
+    url: new URL(`http://localhost:${port}/elastic/`)
+  })
+
+  await connection.request({
+    path: '/_search',
+    method: 'GET'
+  }, options)
+  server.stop()
+})
+
 test('Body request', async t => {
   t.plan(1)
 


### PR DESCRIPTION
Backport of #388 to \`8.x\`.

Conflict in \`src/connection/UndiciConnection.ts\`: the \`8.x\` constructor is flat (no function-agent support), while \`main\` restructured it. Resolution keeps the \`8.x\` structure and applies only the minimal fix: \`new Pool(this.url.toString(), ...)\` → \`new Pool(this.url.origin, ...)\`.

Please review \`src/connection/UndiciConnection.ts\` carefully before merging.