### PR TITLE
Bump 8.10.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elastic/transport",
-  "version": "8.10.1",
+  "version": "8.10.2",
   "description": "Transport classes and utilities shared among Node.js Elastic client libraries",
   "main": "./index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Release prep for 8.10.2.

Changes since 8.10.1:
- fix: support path prefix in node URL (#388, backported in #398) — `UndiciConnection` was passing `url.toString()` to `undici.Pool`, which dropped path prefixes. Changed to `url.origin`.
- ci: restore Node 18 with `--experimental-global-webcrypto` for tap's processinfo (#398)