### PR TITLE
fix(ci): switch backport resolver to openrouter secrets

### DIFF
--- a/.github/workflows/resolve-conflicts.yml
+++ b/.github/workflows/resolve-conflicts.yml
@@ -5,10 +5,15 @@ on:
 
 jobs:
   resolve:
+    if: |
+      (github.event.comment.user.login == 'github-actions[bot]' ||
+       github.event.comment.user.login == 'elastic-vault-github-plugin-prod[bot]') &&
+      contains(github.event.comment.body, 'To backport manually, run these commands')
     uses: elastic/clients-team-automations/.github/workflows/ai-backport-resolver.yml@main
     with:
       comment_body: ${{ github.event.comment.body }}
       comment_user: ${{ github.event.comment.user.login }}
       pr_number: ${{ github.event.issue.number }}
     secrets:
-      LITELLM_API_KEY: ${{ secrets.LITELLM_API_KEY }}
+      OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+      OPENROUTER_BASE_URL: ${{ secrets.OPENROUTER_BASE_URL }}


### PR DESCRIPTION
Prepares this repo for the org-wide switch from `LITELLM_API_KEY` to `OPENROUTER_API_KEY`/`OPENROUTER_BASE_URL`, matching `elastic/clients-team-automations#37`.

This repo still has `LITELLM_API_KEY` configured and not the new secrets, so don't merge this until `OPENROUTER_API_KEY` and `OPENROUTER_BASE_URL` are added as repository secrets, or the backport resolver will start failing the same way the old one will once `LITELLM_API_KEY` is removed.

Also adds a job-level `if` so the reusable workflow is skipped for comments that aren't backport failures, instead of invoking it for every comment in the repo.